### PR TITLE
v4.4 UPDATE MPI:

### DIFF
--- a/DMFT_ED.f90
+++ b/DMFT_ED.f90
@@ -88,7 +88,7 @@ MODULE DMFT_ED
        get_component_bath,               &
        set_component_bath,               &      
        copy_component_bath,              &
-       save_bath,                        &
+       ! save_bath,                        &
        spin_symmetrize_bath ,            &
        ph_symmetrize_bath   ,            &
        ph_trans_bath        ,            &
@@ -103,6 +103,7 @@ MODULE DMFT_ED
        ed_solve               ,&
        ed_rebuild_sigma       
 
+  USE ED_MPI2B, only: ed_set_MPI
 
   USE ED_GLOC,     only:&
        ed_get_gloc,&
@@ -113,10 +114,10 @@ MODULE DMFT_ED
   USE ED_WEISS,    only: ed_get_weiss,ed_get_weiss_lattice
 
 
-  USE ED_ENERGY,   only: ed_kinetic_energy,ed_kinetic_energy_lattice
+  USE ED_ENERGY,   only: ed_kinetic_energy!,ed_kinetic_energy_lattice
 
 
-  USE ED_CHI2FIT,  only: ed_chi2_fitgf,ed_chi2_fitgf_lattice
+  USE ED_CHI2FIT,  only: ed_chi2_fitgf!,ed_chi2_fitgf_lattice
 
 
 END MODULE DMFT_ED

--- a/ED_BATH.f90
+++ b/ED_BATH.f90
@@ -11,6 +11,7 @@ MODULE ED_BATH
   private
 
 
+
   !##################################################################
   !
   !     USER BATH ROUTINES:
@@ -45,7 +46,7 @@ MODULE ED_BATH
   public :: get_component_bath
   public :: set_component_bath
   public :: copy_component_bath
-  public :: save_bath
+  ! public :: save_bath
 
   !explicit symmetries:
   interface break_symmetry_bath
@@ -109,7 +110,11 @@ MODULE ED_BATH
 
 
 
+
+
+
 contains
+
 
   !##################################################################
   !

--- a/ED_BATH/dmft_aux.f90
+++ b/ED_BATH/dmft_aux.f90
@@ -75,9 +75,8 @@ end subroutine deallocate_dmft_bath
 !PURPOSE  : Initialize the DMFT loop, builindg H parameters and/or 
 !reading previous (converged) solution
 !+------------------------------------------------------------------+
-subroutine init_dmft_bath(dmft_bath_,hwband_)
+subroutine init_dmft_bath(dmft_bath_)
   type(effective_bath) :: dmft_bath_
-  real(8)              :: hwband_
   complex(8)           :: himp_aux(Nspin*Norb,Nspin*Norb)
   real(8)              :: hybr_aux_R,hybr_aux_I
   real(8)              :: himp_aux_R(Nspin*Norb,Nspin*Norb)
@@ -103,23 +102,23 @@ subroutine init_dmft_bath(dmft_bath_,hwband_)
   select case(bath_type)
   case default
      !Get energies:
-     dmft_bath_%e(:,:,1)    =-hwband_ + noise_b(1)
-     dmft_bath_%e(:,:,Nbath)= hwband_ + noise_b(Nbath)
+     dmft_bath_%e(:,:,1)    =-hwband + noise_b(1)
+     dmft_bath_%e(:,:,Nbath)= hwband + noise_b(Nbath)
      Nh=Nbath/2
      if(mod(Nbath,2)==0.and.Nbath>=4)then
-        de=hwband_/max(Nh-1,1)
+        de=hwband/max(Nh-1,1)
         dmft_bath_%e(:,:,Nh)  = -1.d-3 + noise_b(Nh)
         dmft_bath_%e(:,:,Nh+1)=  1.d-3 + noise_b(Nh+1)
         do i=2,Nh-1
-           dmft_bath_%e(:,:,i)   =-hwband_ + (i-1)*de  + noise_b(i)
-           dmft_bath_%e(:,:,Nbath-i+1)= hwband_ - (i-1)*de + noise_b(Nbath-i+1)
+           dmft_bath_%e(:,:,i)   =-hwband + (i-1)*de  + noise_b(i)
+           dmft_bath_%e(:,:,Nbath-i+1)= hwband - (i-1)*de + noise_b(Nbath-i+1)
         enddo
      elseif(mod(Nbath,2)/=0.and.Nbath>=3)then
-        de=hwband_/Nh
+        de=hwband/Nh
         dmft_bath_%e(:,:,Nh+1)= 0.0d0 + noise_b(Nh+1)
         do i=2,Nh
-           dmft_bath_%e(:,:,i)        =-hwband_ + (i-1)*de + noise_b(i)
-           dmft_bath_%e(:,:,Nbath-i+1)= hwband_ - (i-1)*de + noise_b(Nbath-i+1)
+           dmft_bath_%e(:,:,i)        =-hwband + (i-1)*de + noise_b(i)
+           dmft_bath_%e(:,:,Nbath-i+1)= hwband - (i-1)*de + noise_b(Nbath-i+1)
         enddo
      endif
      !Get spin-keep yhbridizations
@@ -178,7 +177,7 @@ subroutine init_dmft_bath(dmft_bath_,hwband_)
   !
   inquire(file=trim(Hfile)//trim(ed_file_suffix)//".restart",exist=IOfile)
   if(IOfile)then
-     if(ED_MPI_ID==0)write(LOGfile,"(A)")'Reading bath from file'//trim(Hfile)//trim(ed_file_suffix)//".restart"
+     write(LOGfile,"(A)")'Reading bath from file'//trim(Hfile)//trim(ed_file_suffix)//".restart"
      unit = free_unit()
      flen = file_length(trim(Hfile)//trim(ed_file_suffix)//".restart")
      !

--- a/ED_BATH/user_aux.f90
+++ b/ED_BATH/user_aux.f90
@@ -1007,34 +1007,32 @@ end subroutine copy_spin_orb_component_bath
 
 
 
-!+-----------------------------------------------------------------------------+!
-!PURPOSE: save the user defined bath to a file
-!+-----------------------------------------------------------------------------+!
-subroutine save_bath(bath_,file,used)
-  real(8),dimension(:)      :: bath_
-  type(effective_bath)      :: dmft_bath_
-  character(len=*),optional :: file
-  character(len=256)        :: file_
-  logical,optional          :: used
-  logical                   :: used_,check
-  character(len=16)         :: extension
-  integer                   :: unit_
-  if(ED_MPI_ID==0)then
-     check= check_bath_dimension(bath_)
-     if(.not.check)stop "save_bath error: wrong bath dimensions"
-     call allocate_dmft_bath(dmft_bath_)
-     call set_dmft_bath(bath_,dmft_bath_)
-     used_=.false.;if(present(used))used_=used
-     extension=".restart";if(used_)extension=".used"
-     file_=reg(reg(Hfile)//reg(ed_file_suffix)//reg(extension))
-     if(present(file))file_=reg(file)
-     unit_=free_unit()
-     open(unit_,file=reg(file_))
-     call write_dmft_bath(dmft_bath_,unit_)
-     close(unit_)
-     call deallocate_dmft_bath(dmft_bath_)
-  endif
-end subroutine save_bath
+! !+-----------------------------------------------------------------------------+!
+! !PURPOSE: save the user defined bath to a file
+! !+-----------------------------------------------------------------------------+!
+! subroutine save_bath(bath_,file,used)
+!   real(8),dimension(:)      :: bath_
+!   type(effective_bath)      :: dmft_bath_
+!   character(len=*),optional :: file
+!   character(len=256)        :: file_
+!   logical,optional          :: used
+!   logical                   :: used_,check
+!   character(len=16)         :: extension
+!   integer                   :: unit_
+!   check= check_bath_dimension(bath_)
+!   if(.not.check)stop "save_bath error: wrong bath dimensions"
+!   call allocate_dmft_bath(dmft_bath_)
+!   call set_dmft_bath(bath_,dmft_bath_)
+!   used_=.false.;if(present(used))used_=used
+!   extension=".restart";if(used_)extension=".used"
+!   file_=reg(reg(Hfile)//reg(ed_file_suffix)//reg(extension))
+!   if(present(file))file_=reg(file)
+!   unit_=free_unit()
+!   open(unit_,file=reg(file_))
+!   call write_dmft_bath(dmft_bath_,unit_)
+!   close(unit_)
+!   call deallocate_dmft_bath(dmft_bath_)
+! end subroutine save_bath
 
 
 
@@ -1111,7 +1109,7 @@ subroutine spin_symmetrize_bath_site(bath_,save)
   logical                :: save_
   save_=.true.;if(present(save))save_=save
   if(Nspin==1)then
-     if(ED_MPI_ID==0)write(LOGfile,"(A)")"spin_symmetrize_bath: Nspin=1 nothing to symmetrize"
+     write(LOGfile,"(A)")"spin_symmetrize_bath: Nspin=1 nothing to symmetrize"
      return
   endif
   !

--- a/ED_CHI2FIT.f90
+++ b/ED_CHI2FIT.f90
@@ -10,30 +10,48 @@ MODULE ED_CHI2FIT
   USE ED_AUX_FUNX
   USE ED_BATH
   USE ED_BATH_FUNCTIONS
+#ifdef _MPI
+  USE MPI
+  USE SF_MPI
+#endif
+
 
   implicit none
   private
 
   interface ed_chi2_fitgf
+     !THese are strictly serial:
      module procedure chi2_fitgf_generic_normal
      module procedure chi2_fitgf_generic_normal_NOSPIN
      module procedure chi2_fitgf_generic_superc
      module procedure chi2_fitgf_generic_superc_NOSPIN
-  end interface ed_chi2_fitgf
 
-  interface ed_chi2_fitgf_lattice
      module procedure ed_fit_bath_sites_normal
      module procedure ed_fit_bath_sites_normal_1b
      module procedure ed_fit_bath_sites_normal_mb
-     !
      module procedure ed_fit_bath_sites_superc
      module procedure ed_fit_bath_sites_superc_1b
      module procedure ed_fit_bath_sites_superc_mb
-  end interface ed_chi2_fitgf_lattice
+
+#ifdef _MPI
+     module procedure chi2_fitgf_generic_normal_mpi
+     module procedure chi2_fitgf_generic_normal_NOSPIN_mpi
+     module procedure chi2_fitgf_generic_superc_mpi
+     module procedure chi2_fitgf_generic_superc_NOSPIN_mpi
+
+     module procedure ed_fit_bath_sites_normal_mpi
+     module procedure ed_fit_bath_sites_normal_1b_mpi
+     module procedure ed_fit_bath_sites_normal_mb_mpi
+     module procedure ed_fit_bath_sites_superc_mpi
+     module procedure ed_fit_bath_sites_superc_1b_mpi
+     module procedure ed_fit_bath_sites_superc_mb_mpi
+#endif
+  end interface ed_chi2_fitgf
 
 
   public :: ed_chi2_fitgf
-  public :: ed_chi2_fitgf_lattice
+
+
   integer                               :: Ldelta
   complex(8),dimension(:,:),allocatable :: Gdelta
   complex(8),dimension(:,:),allocatable :: Fdelta
@@ -44,91 +62,75 @@ MODULE ED_CHI2FIT
   type(effective_bath)                  :: chi2_bath
   integer                               :: cg_iter_count=0
 
+  integer                               :: MPI_RANK=0
+  integer                               :: MPI_SIZE=1
+  logical                               :: MPI_MASTER=.true.
+  integer                               :: MPI_IERR
+
+
+
 contains
 
 
-  !+-------------------------------------------------------------+
+  !+----------------------------------------------------------------------+
   !PURPOSE  : Chi^2 fit of the G0/Delta 
   !
   ! - CHI2_FITGF_GENERIC_NORMAL interface for the normal case 
-  !
   ! - CHI2_FITGF_GENERIC_SUPERC interface for the superconducting case 
-  !
   !   * CHI2_FITGF_GENERIC_NORMAL_NOSPIN interface to fixed spin input
-  !
   !   * CHI2_FITGF_GENERIC_SUPERC_NOSPIN interface to fixed spin input
-  !+-------------------------------------------------------------+
-  !NORMAL:
+  !+----------------------------------------------------------------------+
+  !+----------------------------------------------------------------------+
+  !                                NORMAL                                 !
+  !+----------------------------------------------------------------------+
   subroutine chi2_fitgf_generic_normal(fg,bath,ispin)
     complex(8),dimension(:,:,:,:,:) :: fg ![Nspin][Nspin][Norb][Norb][Niw] 
     real(8),dimension(:)            :: bath
     integer,optional                :: ispin
     integer                         :: ispin_
     ispin_=1;if(present(ispin))ispin_=ispin
-    if(ED_MPI_ID==0)then
-       call assert_shape(fg,[Nspin,Nspin,Norb,Norb,size(fg,5)],"chi2_fitgf_generic_normal","fg")
-       select case(cg_method)
-       case (0)
-          if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-nr and CG-weight: ",cg_weight," on: ",cg_scheme
-       case (1)
-          if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-minimize and CG-weight: ",cg_weight," on: ",cg_scheme
-       case(2)
-          if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-plus and CG-weight: ",cg_weight," on: ",cg_scheme
-       case default
-          stop "chi2_fitgf_generic_normal error: cg_method > 2"
-       end select
-    endif
+    call assert_shape(fg,[Nspin,Nspin,Norb,Norb,size(fg,5)],"chi2_fitgf_generic_normal","fg")
+    select case(cg_method)
+    case (0)
+       if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-nr and CG-weight: ",cg_weight," on: ",cg_scheme
+    case (1)
+       if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-minimize and CG-weight: ",cg_weight," on: ",cg_scheme
+    case(2)
+       if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-plus and CG-weight: ",cg_weight," on: ",cg_scheme
+    case default
+       stop "chi2_fitgf_generic_normal error: cg_method > 2"
+    end select
     !
     select case(bath_type)
     case default
-       !
        select case(ed_mode)
        case ("normal")
-          !
           call chi2_fitgf_normal_normal(fg(ispin_,ispin_,:,:,:),bath,ispin_)
-          !
        case ("nonsu2")
-          !
           if(present(ispin))then
              write(LOGfile,"(A)")"chi2_fitgf_generic_normal WARNING: ed_mode=nonsu2 but only ONE spin orientation required. disregarded"
              call sleep(1)
           endif
           call chi2_fitgf_normal_nonsu2(fg(:,:,:,:,:),bath)
-          !
        case default
-          !
           stop "chi2_fitgf ERROR: ed_mode!=normal/nonsu2 but only NORMAL component is provided"
-          !
        end select
-       !
     case ("hybrid")
        select case(ed_mode)
        case ("normal")
-          !
           call chi2_fitgf_hybrid_normal(fg(ispin_,ispin_,:,:,:),bath,ispin_)
-          !
        case ("nonsu2")
-          !
           if(present(ispin))then
              write(LOGfile,"(A)")"chi2_fitgf_generic_normal WARNING: ed_mode=nonsu2 but only ONE spin orientation required. disregarded"
              call sleep(1)
           endif
           call chi2_fitgf_hybrid_nonsu2(fg(:,:,:,:,:),bath)
-          !
        case default
-          !
           stop "chi2_fitgf ERROR: ed_mode!=normal/nonsu2 but only NORMAL component is provided" 
-          !
        end select
-       !
     case ("replica")
-       !
        call chi2_fitgf_replica(fg,bath)
-       !
     end select
-    ! #ifdef _MPI
-    !     call MPI_BCAST(bath,size(bath),MPI_DOUBLE_PRECISION,0,ED_MPI_COMM,ED_MPI_ERR)
-    ! #endif
     !set trim_state_list to true after the first fit has been done: this 
     !marks the ends of the cycle of the 1st DMFT loop.
     trim_state_list=.true.
@@ -149,59 +151,130 @@ contains
 
 
 
+#ifdef _MPI
+  subroutine chi2_fitgf_generic_normal_mpi(comm,fg,bath,ispin)
+    integer                         :: comm
+    complex(8),dimension(:,:,:,:,:) :: fg ![Nspin][Nspin][Norb][Norb][Niw] 
+    real(8),dimension(:)            :: bath
+    integer,optional                :: ispin
+    integer                         :: ispin_
+    !
+    MPI_MASTER=get_Master_MPI(comm)
+    !
+    ispin_=1;if(present(ispin))ispin_=ispin
+    call assert_shape(fg,[Nspin,Nspin,Norb,Norb,size(fg,5)],"chi2_fitgf_generic_normal","fg")
+    if(MPI_MASTER)then
+       select case(cg_method)
+       case (0)
+          if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-nr and CG-weight: ",cg_weight," on: ",cg_scheme
+       case (1)
+          if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-minimize and CG-weight: ",cg_weight," on: ",cg_scheme
+       case(2)
+          if(ed_verbose<3)write(LOGfile,"(A,I1,A,A)")"\Chi2 fit with CG-plus and CG-weight: ",cg_weight," on: ",cg_scheme
+       case default
+          stop "chi2_fitgf_generic_normal error: cg_method > 2"
+       end select
+       !
+       select case(bath_type)
+       case default
+          select case(ed_mode)
+          case ("normal")
+             call chi2_fitgf_normal_normal(fg(ispin_,ispin_,:,:,:),bath,ispin_)
+          case ("nonsu2")
+             if(present(ispin))then
+                write(LOGfile,"(A)")"chi2_fitgf_generic_normal WARNING: ed_mode=nonsu2 but only ONE spin orientation required. disregarded"
+                call sleep(1)
+             endif
+             call chi2_fitgf_normal_nonsu2(fg(:,:,:,:,:),bath)
+          case default
+             stop "chi2_fitgf ERROR: ed_mode!=normal/nonsu2 but only NORMAL component is provided"
+          end select
+       case ("hybrid")
+          select case(ed_mode)
+          case ("normal")
+             call chi2_fitgf_hybrid_normal(fg(ispin_,ispin_,:,:,:),bath,ispin_)
+          case ("nonsu2")
+             if(present(ispin))then
+                write(LOGfile,"(A)")"chi2_fitgf_generic_normal WARNING: ed_mode=nonsu2 but only ONE spin orientation required. disregarded"
+                call sleep(1)
+             endif
+             call chi2_fitgf_hybrid_nonsu2(fg(:,:,:,:,:),bath)
+          case default
+             stop "chi2_fitgf ERROR: ed_mode!=normal/nonsu2 but only NORMAL component is provided" 
+          end select
+       case ("replica")
+          call chi2_fitgf_replica(fg,bath)
+       end select
+    endif
+    !
+    call Bcast_MPI(comm,bath)
+    !
+    !set trim_state_list to true after the first fit has been done: this 
+    !marks the ends of the cycle of the 1st DMFT loop.
+    trim_state_list=.true.
+  end subroutine chi2_fitgf_generic_normal_mpi
 
-  !SUPERC:
+  subroutine chi2_fitgf_generic_normal_NOSPIN_mpi(comm,fg,bath,ispin)
+    integer :: comm
+    complex(8),dimension(:,:,:)                      :: fg ![Norb][Norb][Niw]
+    complex(8),dimension(Nspin,Nspin,Norb,Norb,Lfit) :: fg_
+    real(8),dimension(:),intent(inout)               :: bath
+    integer,optional                                 :: ispin
+    integer                                          :: ispin_
+    ispin_=1;if(present(ispin))ispin_=ispin
+    if(size(fg,3)<Lfit)stop "chi2_fitgf_generic_normal_NOSPIN error: size[fg,3] < Lfit" 
+    fg_=zero
+    fg_(ispin_,ispin_,:,:,1:Lfit) = fg(:,:,1:Lfit)
+    call chi2_fitgf_generic_normal_mpi(comm,fg_,bath,ispin_)
+  end subroutine chi2_fitgf_generic_normal_NOSPIN_mpi
+#endif
+
+
+
+
+
+
+
+  !+----------------------------------------------------------------------+
+  !                                SUPERC                                 !
+  !+----------------------------------------------------------------------+
   subroutine chi2_fitgf_generic_superc(fg,bath,ispin)
     complex(8),dimension(:,:,:,:,:,:) :: fg ![2][Nspin][Nspin][Norb][Norb][Niw]
     real(8),dimension(:)            :: bath
     integer,optional                :: ispin
     integer                         :: ispin_
     ispin_=1;if(present(ispin))ispin_=ispin
-    if(ED_MPI_ID==0)then
-       call assert_shape(fg,[2,Nspin,Nspin,Norb,Norb,size(fg,6)],"chi2_fitgf_generic_superc","fg")
-       select case(cg_method)
-       case (0)
-          if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-nr"
-       case (1)
-          if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-minimize"
-       case(2)
-          if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-plus"
-       case default
-          stop "chi2_fitgf_generic_superc error: cg_method > 2"
-       end select
-    endif
+    call assert_shape(fg,[2,Nspin,Nspin,Norb,Norb,size(fg,6)],"chi2_fitgf_generic_superc","fg")
+    select case(cg_method)
+    case (0)
+       if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-nr"
+    case (1)
+       if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-minimize"
+    case(2)
+       if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-plus"
+    case default
+       stop "chi2_fitgf_generic_superc error: cg_method > 2"
+    end select
     select case(bath_type)
     case default
        select case(ed_mode)
        case ("superc")
-          !
           call chi2_fitgf_normal_superc(fg(:,ispin_,ispin_,:,:,:),bath,ispin_)
-          !
        case default
-          !
           write(LOGfile,"(A)") "chi2_fitgf WARNING: ed_mode=normal/nonsu2 but NORMAL & ANOMAL components provided."
           call sleep(1)
           call chi2_fitgf_normal_normal(fg(1,ispin_,ispin_,:,:,:),bath,ispin_)          
-          !
        end select
-       !
     case ("hybrid")
        select case(ed_mode)
        case ("superc")
-          !
           call chi2_fitgf_hybrid_superc(fg(:,ispin_,ispin_,:,:,:),bath,ispin_)
-          !
        case default
-          !
           write(LOGfile,"(A)") "chi2_fitgf WARNING: ed_mode=normal/nonsu2 but NORMAL & ANOMAL components provided."
           call sleep(1)
           call chi2_fitgf_hybrid_normal(fg(1,ispin_,ispin_,:,:,:),bath,ispin_)          
-          !
        end select
     end select
-    ! #ifdef _MPI
-    !     call MPI_BCAST(bath,size(bath),MPI_DOUBLE_PRECISION,0,ED_MPI_COMM,ED_MPI_ERR)
-    ! #endif
     !set trim_state_list to true after the first fit has been done: this 
     !marks the ends of the cycle of the 1st DMFT loop.
     trim_state_list=.true.
@@ -220,6 +293,73 @@ contains
     call chi2_fitgf_generic_superc(fg_,bath,ispin_)
   end subroutine chi2_fitgf_generic_superc_NOSPIN
 
+
+#ifdef _MPI
+  subroutine chi2_fitgf_generic_superc_mpi(comm,fg,bath,ispin)
+    integer                           :: comm
+    complex(8),dimension(:,:,:,:,:,:) :: fg ![2][Nspin][Nspin][Norb][Norb][Niw]
+    real(8),dimension(:)              :: bath
+    integer,optional                  :: ispin
+    integer                           :: ispin_
+    !
+    MPI_MASTER=get_Master_MPI(comm)
+    !
+    ispin_=1;if(present(ispin))ispin_=ispin
+    call assert_shape(fg,[2,Nspin,Nspin,Norb,Norb,size(fg,6)],"chi2_fitgf_generic_superc","fg")
+    if(MPI_MASTER)then
+       select case(cg_method)
+       case (0)
+          if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-nr"
+       case (1)
+          if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-minimize"
+       case(2)
+          if(ed_verbose<3)write(LOGfile,"(A)")"\Chi2 fit with CG-plus"
+       case default
+          stop "chi2_fitgf_generic_superc error: cg_method > 2"
+       end select
+       select case(bath_type)
+       case default
+          select case(ed_mode)
+          case ("superc")
+             call chi2_fitgf_normal_superc(fg(:,ispin_,ispin_,:,:,:),bath,ispin_)
+          case default
+             write(LOGfile,"(A)") "chi2_fitgf WARNING: ed_mode=normal/nonsu2 but NORMAL & ANOMAL components provided."
+             call sleep(1)
+             call chi2_fitgf_normal_normal(fg(1,ispin_,ispin_,:,:,:),bath,ispin_)          
+          end select
+       case ("hybrid")
+          select case(ed_mode)
+          case ("superc")
+             call chi2_fitgf_hybrid_superc(fg(:,ispin_,ispin_,:,:,:),bath,ispin_)
+          case default
+             write(LOGfile,"(A)") "chi2_fitgf WARNING: ed_mode=normal/nonsu2 but NORMAL & ANOMAL components provided."
+             call sleep(1)
+             call chi2_fitgf_hybrid_normal(fg(1,ispin_,ispin_,:,:,:),bath,ispin_)          
+          end select
+       end select
+    endif
+    !
+    call Bcast_MPI(comm,bath)
+    !
+    !set trim_state_list to true after the first fit has been done: this 
+    !marks the ends of the cycle of the 1st DMFT loop.
+    trim_state_list=.true.
+  end subroutine chi2_fitgf_generic_superc_mpi
+
+  subroutine chi2_fitgf_generic_superc_NOSPIN_mpi(comm,fg,bath,ispin)
+    integer                                            :: comm
+    complex(8),dimension(:,:,:,:)                      :: fg ![2][Norb][Norb][Niw]
+    complex(8),dimension(2,Nspin,Nspin,Norb,Norb,Lfit) :: fg_
+    real(8),dimension(:),intent(inout)                 :: bath
+    integer,optional                                   :: ispin
+    integer                                            :: ispin_
+    ispin_=1;if(present(ispin))ispin_=ispin
+    if(size(fg,4)<Lfit)stop "chi2_fitgf_generic_superc_NOSPIN error: size[fg,4] < Lfit"
+    fg_=zero
+    fg_(:,ispin_,ispin_,:,:,1:Lfit) = fg(:,:,:,1:Lfit)
+    call chi2_fitgf_generic_superc_mpi(comm,fg_,bath,ispin_)
+  end subroutine chi2_fitgf_generic_superc_NOSPIN_mpi
+#endif
 
 
 
@@ -253,13 +393,17 @@ contains
 
 
 
-  !+-----------------------------------------------------------------------------+!
-  ! PURPOSE: given a number of independent baths, evaluate N independent Delta/G0
-  ! functions and fit them to update the effective baths for ED.
-  ! - NORMAL
-  !+-----------------------------------------------------------------------------+!
-  subroutine ed_fit_bath_sites_normal(bath,Delta,Hloc,ispin)!,mpicomm)
-    ! integer,optional :: mpicomm
+
+
+
+  !+----------------------------------------------------------------------!
+  ! PURPOSE: given a number of independent baths, evaluate N independent
+  ! Delta/G0 functions and fit them to update the effective baths for ED.
+  !+----------------------------------------------------------------------!
+  !+----------------------------------------------------------------------+
+  !                                NORMAL                                 !
+  !+----------------------------------------------------------------------+
+  subroutine ed_fit_bath_sites_normal(bath,Delta,Hloc,ispin)
     real(8),intent(inout)    :: bath(:,:)
     complex(8),intent(inout) :: Delta(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
     complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
@@ -270,52 +414,91 @@ contains
     integer                  :: Nsites
     logical                  :: check_dim
     character(len=5)         :: tmp_suffix
-    ! #ifdef _MPI
-    !     if(present(mpicomm))then
-    !        ED_MPI_COMM=mpicomm
-    !     else
-    !        ED_MPI_COMM=MPI_COMM_WORLD
-    !     endif
-    !     ED_MPI_ID=get_Rank_MPI(ED_MPI_COMM)
-    !     ED_MPI_SIZE=get_Size_MPI(ED_MPI_COMM)
-    ! #endif
+    !
     ! Check dimensions !
     Nsites=size(bath,1)
     !
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
-       print*,"check bath",ilat
+    do ilat=1,Nsites
        check_dim = check_bath_dimension(bath(ilat,:))
        if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
     end do
     !
     bath_tmp=0d0
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
+    do ilat = 1, Nsites
        bath_tmp(ilat,:)=bath(ilat,:)
        call set_Hloc(Hloc(ilat,:,:,:,:))
+       !
        ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))!trim(tmp_suffix)
+       !
        if(present(ispin))then
           ispin_=ispin
           if(ispin_>Nspin)stop "ed_fit_bath_sites error: required spin index > Nspin"
           call ed_chi2_fitgf(Delta(ilat,ispin_,ispin_,:,:,:),bath_tmp(ilat,:),ispin=ispin_)
        else
-          !do ispin_=1,Nspin
-          !   call ed_chi2_fitgf(Delta(ilat,ispin_,ispin_,:,:,:),bath_tmp(ilat,:),ispin=ispin_)
-          !enddo
           call ed_chi2_fitgf(Delta(ilat,:,:,:,:,:),bath_tmp(ilat,:))
        end if
     end do
-#ifdef _MPI
-    bath=0d0
-    call MPI_ALLREDUCE(bath_tmp(:,:),bath(:,:),size(bath),MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    call Error_MPI(ED_MPI_ERR,'ed_fit_bath_sites_normal')
-#else
+    !
     bath = bath_tmp
-#endif
-
+    !
     ed_file_suffix=""
   end subroutine ed_fit_bath_sites_normal
 
+#ifdef _MPI
+  subroutine ed_fit_bath_sites_normal_mpi(comm,bath,Delta,Hloc,ispin)
+    integer                  :: comm
+    real(8),intent(inout)    :: bath(:,:)
+    complex(8),intent(inout) :: Delta(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+    complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer,optional         :: ispin
+    !MPI auxiliary vars
+    real(8)                  :: bath_tmp(size(bath,1),size(bath,2))
+    integer                  :: ilat,i,iorb,ispin_
+    integer                  :: Nsites
+    logical                  :: check_dim
+    character(len=5)         :: tmp_suffix
+    !
+    MPI_RANK = get_Rank_MPI(comm)
+    MPI_SIZE = get_Size_MPI(comm)
+    MPI_MASTER=get_Master_MPI(comm)
+    !
+    ! Check dimensions !
+    Nsites=size(bath,1)
+    !
+    do ilat=1+MPI_RANK,Nsites,MPI_SIZE
+       check_dim = check_bath_dimension(bath(ilat,:))
+       if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+    end do
+    !
+    bath_tmp=0d0
+    do ilat = 1+MPI_RANK,Nsites,MPI_SIZE
+       bath_tmp(ilat,:)=bath(ilat,:)
+       call set_Hloc(Hloc(ilat,:,:,:,:))
+       !
+       ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))!trim(tmp_suffix)
+       !
+       if(present(ispin))then
+          ispin_=ispin
+          if(ispin_>Nspin)stop "ed_fit_bath_sites error: required spin index > Nspin"
+          call ed_chi2_fitgf(Delta(ilat,ispin_,ispin_,:,:,:),bath_tmp(ilat,:),ispin=ispin_)
+       else
+          call ed_chi2_fitgf(Delta(ilat,:,:,:,:,:),bath_tmp(ilat,:))
+       end if
+    end do
+    !
+    bath=0d0
+    call MPI_ALLREDUCE(bath_tmp(:,:),bath(:,:),size(bath),MPI_DOUBLE_PRECISION,MPI_SUM,comm,MPI_IERR)
+    !
+    ed_file_suffix=""
+  end subroutine ed_fit_bath_sites_normal_mpi
+#endif
+
+
+
+
+
   subroutine ed_fit_bath_sites_normal_1b(bath,Delta,Hloc,spin)
+    integer                  :: comm
     real(8),intent(inout)    :: bath(:,:)
     complex(8),intent(inout) :: Delta(size(bath,1),Lmats)
     complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
@@ -331,7 +514,31 @@ contains
     endif
   end subroutine ed_fit_bath_sites_normal_1b
 
+#ifdef _MPI
+  subroutine ed_fit_bath_sites_normal_1b_mpi(comm,bath,Delta,Hloc,spin)
+    integer                  :: comm
+    real(8),intent(inout)    :: bath(:,:)
+    complex(8),intent(inout) :: Delta(size(bath,1),Lmats)
+    complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer,optional         :: spin
+    complex(8)               :: Delta_(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+    if(Norb>1)stop "ed_fit_bath_sites_hloc_1b error: Norb > 1 in 1-band routine" 
+    if(Nspin>1)stop "ed_fit_bath_sites_hloc_1b error: Nspin > 1 in 1-band routine" 
+    Delta_(:,1,1,1,1,:) = Delta
+    if(present(spin))then
+       call ed_fit_bath_sites_normal_mpi(comm,bath,Delta_,Hloc,spin)
+    else
+       call ed_fit_bath_sites_normal_mpi(comm,bath,Delta_,Hloc)
+    endif
+  end subroutine ed_fit_bath_sites_normal_1b_mpi
+#endif
+
+
+
+
+
   subroutine ed_fit_bath_sites_normal_mb(bath,Delta,Hloc,spin)
+    integer                  :: comm
     real(8),intent(inout)    :: bath(:,:)
     complex(8),intent(inout) :: Delta(size(bath,1),Norb,Norb,Lmats)
     complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
@@ -346,6 +553,29 @@ contains
     endif
   end subroutine ed_fit_bath_sites_normal_mb
 
+#ifdef _MPI
+  subroutine ed_fit_bath_sites_normal_mb_mpi(comm,bath,Delta,Hloc,spin)
+    integer                  :: comm
+    real(8),intent(inout)    :: bath(:,:)
+    complex(8),intent(inout) :: Delta(size(bath,1),Norb,Norb,Lmats)
+    complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer,optional         :: spin
+    complex(8)               :: Delta_(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+    if(Nspin>1)stop "ed_fit_bath_sites_hloc_mb error: Nspin > 1 in M-band routine" 
+    Delta_(:,1,1,:,:,:) = Delta
+    if(present(spin))then
+       call ed_fit_bath_sites_normal_mpi(comm,bath,Delta_,Hloc,spin)
+    else
+       call ed_fit_bath_sites_normal_mpi(comm,bath,Delta_,Hloc)
+    endif
+  end subroutine ed_fit_bath_sites_normal_mb_mpi
+#endif
+
+
+
+
+
+
 
 
 
@@ -355,9 +585,12 @@ contains
   !+-----------------------------------------------------------------------------+!
   ! PURPOSE: given a number of independent baths, evaluate N independent Delta/G0
   ! functions and fit them to update the effective baths for ED.
-  ! - SUPERC
   !+-----------------------------------------------------------------------------+!
+  !+----------------------------------------------------------------------+
+  !                                SUPERC                                 !
+  !+----------------------------------------------------------------------+
   subroutine ed_fit_bath_sites_superc(bath,Delta,Hloc,ispin)
+    integer                  :: comm
     real(8),intent(inout)    :: bath(:,:)
     complex(8),intent(inout) :: Delta(2,size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
     complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
@@ -370,20 +603,21 @@ contains
     !
     Nsites=size(bath,1)
     !
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
+    do ilat = 1+MPI_RANK,Nsites,MPI_SIZE
        check_dim = check_bath_dimension(bath(ilat,:))
        if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
     end do
     !
     bath_tmp=0.d0
     !
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
+    do ilat=1, Nsites
        !
        bath_tmp(ilat,:) = bath(ilat,:)
        !
        call set_Hloc(Hloc(ilat,:,:,:,:))
-       !write(tmp_suffix,'(I4.4)') ilat
+       !
        ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))!trim(tmp_suffix)
+       !
        if(present(ispin))then
           ispin_=ispin
           if(ispin_>Nspin)stop "ed_fit_bath_sites error: required spin index > Nspin"
@@ -394,15 +628,69 @@ contains
           enddo
        endif
     end do
-#ifdef _MPI
-    call MPI_ALLREDUCE(bath_tmp,bath,size(bath),MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-#else
     bath = bath_tmp
-#endif
     ed_file_suffix=""
   end subroutine ed_fit_bath_sites_superc
 
+#ifdef _MPI
+  subroutine ed_fit_bath_sites_superc_mpi(comm,bath,Delta,Hloc,ispin)
+    integer                  :: comm
+    real(8),intent(inout)    :: bath(:,:)
+    complex(8),intent(inout) :: Delta(2,size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+    complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer,optional         :: ispin
+    !MPI auxiliary
+    real(8)                  :: bath_tmp(size(bath,1),size(bath,2))
+    integer                  :: ilat,i,iorb,ispin_,Nsites
+    logical                  :: check_dim
+    character(len=5)         :: tmp_suffix
+    !
+    MPI_RANK = get_Rank_MPI(comm)
+    MPI_SIZE = get_Size_MPI(comm)
+    MPI_MASTER=get_Master_MPI(comm)
+    !
+    Nsites=size(bath,1)
+    !
+    do ilat = 1 + MPI_RANK, Nsites, MPI_SIZE
+       check_dim = check_bath_dimension(bath(ilat,:))
+       if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+    end do
+    !
+    bath_tmp=0.d0
+    !
+    do ilat= 1 + MPI_RANK, Nsites, MPI_SIZE
+       !
+       bath_tmp(ilat,:) = bath(ilat,:)
+       !
+       call set_Hloc(Hloc(ilat,:,:,:,:))
+       !
+       ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))!trim(tmp_suffix)
+       !
+       if(present(ispin))then
+          ispin_=ispin
+          if(ispin_>Nspin)stop "ed_fit_bath_sites error: required spin index > Nspin"
+          call ed_chi2_fitgf(Delta(:,ilat,ispin_,ispin_,:,:,:),bath_tmp(ilat,:),ispin_)
+       else
+          do ispin_=1,Nspin
+             call ed_chi2_fitgf(Delta(:,ilat,ispin_,ispin_,:,:,:),bath_tmp(ilat,:),ispin_)
+          enddo
+       endif
+    end do
+    !
+    bath=0d0
+    call MPI_ALLREDUCE(bath_tmp,bath,size(bath),MPI_DOUBLE_PRECISION,MPI_SUM,comm,MPI_IERR)
+    !
+    ed_file_suffix=""
+  end subroutine ed_fit_bath_sites_superc_mpi
+#endif
+
+
+
+
+
+
   subroutine ed_fit_bath_sites_superc_1b(bath,Delta,Hloc,ispin)
+    integer                  :: comm
     real(8),intent(inout)    :: bath(:,:)
     complex(8),intent(inout) :: Delta(2,size(bath,1),Lmats)
     complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
@@ -417,6 +705,29 @@ contains
        call ed_fit_bath_sites_superc(bath,Delta_,Hloc)
     endif
   end subroutine ed_fit_bath_sites_superc_1b
+
+#ifdef _MPI
+  subroutine ed_fit_bath_sites_superc_1b_mpi(comm,bath,Delta,Hloc,ispin)
+    integer                  :: comm
+    real(8),intent(inout)    :: bath(:,:)
+    complex(8),intent(inout) :: Delta(2,size(bath,1),Lmats)
+    complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer,optional         :: ispin
+    complex(8)               :: Delta_(2,size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+    if(Norb>1)stop "ed_fit_bath_sites_superc_1b error: Norb > 1 in 1-band routine" 
+    if(Nspin>1)stop "ed_fit_bath_sites_superc_1b error: Nspin > 1 in 1-band routine" 
+    Delta_(:,:,1,1,1,1,:) = Delta
+    if(present(ispin))then
+       call ed_fit_bath_sites_superc_mpi(comm,bath,Delta_,Hloc,ispin)
+    else
+       call ed_fit_bath_sites_superc_mpi(comm,bath,Delta_,Hloc)
+    endif
+  end subroutine ed_fit_bath_sites_superc_1b_mpi
+#endif
+
+
+
+
 
   subroutine ed_fit_bath_sites_superc_mb(bath,Delta,Hloc,ispin)
     real(8),intent(inout)    :: bath(:,:)
@@ -433,6 +744,22 @@ contains
     endif
   end subroutine ed_fit_bath_sites_superc_mb
 
-
+#ifdef _MPI
+  subroutine ed_fit_bath_sites_superc_mb_mpi(comm,bath,Delta,Hloc,ispin)
+    integer                  :: comm
+    real(8),intent(inout)    :: bath(:,:)
+    complex(8),intent(inout) :: Delta(2,size(bath,1),Norb,Norb,Lmats)
+    complex(8)               :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer,optional         :: ispin
+    complex(8)               :: Delta_(2,size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+    if(Nspin>1)stop "ed_fit_bath_sites_superc_mb error: Nspin > 1 in M-band routine" 
+    Delta_(:,:,1,1,:,:,:) = Delta
+    if(present(ispin))then
+       call ed_fit_bath_sites_superc_mpi(comm,bath,Delta_,Hloc,ispin)
+    else
+       call ed_fit_bath_sites_superc_mpi(comm,bath,Delta_,Hloc)
+    endif
+  end subroutine ed_fit_bath_sites_superc_mb_mpi
+#endif
 
 end MODULE ED_CHI2FIT

--- a/ED_CHI2FIT/fitgf_normal_normal.f90
+++ b/ED_CHI2FIT/fitgf_normal_normal.f90
@@ -119,7 +119,7 @@ subroutine chi2_fitgf_normal_normal(fg,bath_,ispin)
      end select
      !
      !
-     if(ED_MPI_ID==0)write(LOGfile,"(A,ES18.9,A,I5,A)")&
+     write(LOGfile,"(A,ES18.9,A,I5,A)")&
           "chi^2|iter"//reg(ed_file_suffix)//'= ',chi," | ",iter,&
           "  <--  Orb"//reg(txtfy(iorb))//" Spin"//reg(txtfy(ispin))
      !

--- a/ED_CHI2FIT/fitgf_replica.f90
+++ b/ED_CHI2FIT/fitgf_replica.f90
@@ -94,9 +94,9 @@ subroutine chi2_fitgf_replica(fg,bath_)
      Wdelta=Xdelta
   end select
   !
-  if(ED_MPI_ID==0)write(LOGfile,*)"  fitted functions",totNso
+  write(LOGfile,*)"  fitted functions",totNso
   do i=1,totNso
-     if(ED_MPI_ID==0)write(LOGfile,*)"  s,s',a,b",getIspin(i),getJspin(i),getIorb(i),getJorb(i)
+     write(LOGfile,*)"  s,s',a,b",getIspin(i),getJspin(i),getIorb(i),getJorb(i)
      Gdelta(i,1:Ldelta) = fg(getIspin(i),getJspin(i),getIorb(i),getJorb(i),1:Ldelta)
   enddo
   !
@@ -133,7 +133,7 @@ subroutine chi2_fitgf_replica(fg,bath_)
      !
   end select
   !
-  if(ED_MPI_ID==0)write(LOGfile,"(A,ES18.9,A,I5,A)")"chi^2|iter"//reg(ed_file_suffix)//'= ',chi," | ",iter,"  <--  All Orbs, All Spins"
+  write(LOGfile,"(A,ES18.9,A,I5,A)")"chi^2|iter"//reg(ed_file_suffix)//'= ',chi," | ",iter,"  <--  All Orbs, All Spins"
   !
   if(ed_verbose<2)then
      suffix="_ALLorb_ALLspins"//reg(ed_file_suffix)

--- a/ED_ENERGY.f90
+++ b/ED_ENERGY.f90
@@ -4,10 +4,13 @@
 MODULE ED_ENERGY
   USE ED_INPUT_VARS
   USE ED_VARS_GLOBAL
-  USE ED_EIGENSPACE
+  ! USE ED_EIGENSPACE
   USE ED_SETUP
   USE ED_AUX_FUNX
-  USE ED_MATVEC
+  ! USE ED_MATVEC
+  !
+  USE ED_MPI2B
+  !
   USE SF_CONSTANTS, only:zero,pi,xi
   USE SF_IOTOOLS, only:free_unit,reg,txtfy
   USE SF_ARRAYS, only: arange
@@ -21,279 +24,32 @@ MODULE ED_ENERGY
 
   interface ed_kinetic_energy
      module procedure kinetic_energy_impurity_normal_main
-     module procedure kinetic_energy_impurity_superc_main
      module procedure kinetic_energy_impurity_normal_1B
      module procedure kinetic_energy_impurity_normal_MB
+     module procedure kinetic_energy_lattice_normal_main
+     module procedure kinetic_energy_lattice_normal_1
+     module procedure kinetic_energy_lattice_normal_1B     
+
+
+     module procedure kinetic_energy_impurity_superc_main
      module procedure kinetic_energy_impurity_superc_1B
      module procedure kinetic_energy_impurity_superc_MB
-  end interface ed_kinetic_energy
-
-  interface ed_kinetic_energy_lattice
-     module procedure kinetic_energy_lattice_normal_main
      module procedure kinetic_energy_lattice_superc_main
-     module procedure kinetic_energy_lattice_normal_1
-     module procedure kinetic_energy_lattice_normal_1B
      module procedure kinetic_energy_lattice_superc_1
      module procedure kinetic_energy_lattice_superc_1B
-  end interface ed_kinetic_energy_lattice
+     ! end interface ed_kinetic_energy
+
+     ! interface ed_kinetic_energy_lattice
+  end interface ed_kinetic_energy
 
   !PUBLIC in DMFT
   public :: ed_kinetic_energy
-  public :: ed_kinetic_energy_lattice
+  ! public :: ed_kinetic_energy_lattice
 
-  !INTERNAL in DMFT
-  public :: local_energy_impurity
 
   real(8),dimension(:),allocatable        :: wm
 
 contains 
-
-  !+-------------------------------------------------------------------+
-  !PURPOSE  : Get internal energy from the Impurity problem.
-  !+-------------------------------------------------------------------+
-  subroutine local_energy_impurity()
-    integer,dimension(Nlevels)                        :: ib
-    integer                                           :: i,j
-    integer                                           :: izero
-    integer                                           :: isector
-    integer                                           :: idim
-    integer                                           :: iorb,jorb,ispin
-    integer                                           :: numstates
-    integer                                           :: m,k1,k2,k3,k4
-    real(8)                                           :: sg1,sg2,sg3,sg4
-    real(8)                                           :: Egs,gs_weight
-    real(8)                                           :: Ei
-    real(8)                                           :: peso
-    real(8)                                           :: norm
-    real(8),dimension(Norb)                           :: nup,ndw
-    real(8),dimension(Nspin,Norb)                     :: eloc
-    real(8),dimension(:),pointer                      :: gsvec
-    complex(8),dimension(:),pointer                   :: gscvec
-    type(sector_map) :: H
-    logical                                           :: Jcondition
-    !
-    Egs     = state_list%emin
-    ed_Ehartree= 0.d0
-    ed_Eknot   = 0.d0
-    ed_Epot    = 0.d0
-    ed_Dust    = 0.d0
-    ed_Dund    = 0.d0
-    ed_Dse     = 0.d0
-    ed_Dph     = 0.d0
-    !
-    !Get diagonal part of Hloc
-    do ispin=1,Nspin
-       do iorb=1,Norb
-          eloc(ispin,iorb)=impHloc(ispin,ispin,iorb,iorb)
-       enddo
-    enddo
-    !
-    numstates=state_list%size
-    do izero=1,numstates
-       isector = es_return_sector(state_list,izero)
-       Ei      = es_return_energy(state_list,izero)
-       idim    = getdim(isector)
-       !
-       if(ed_type=='d')then
-          gsvec  => es_return_vector(state_list,izero)
-          norm=sqrt(dot_product(gsvec,gsvec))
-       elseif(ed_type=='c')then
-          gscvec  => es_return_cvector(state_list,izero)
-          norm=sqrt(dot_product(gscvec,gscvec))
-       endif
-       if(abs(norm-1.d0)>1.d-9)stop "GS is not normalized"
-       !
-       peso = 1.d0 ; if(finiteT)peso=exp(-beta*(Ei-Egs))
-       peso = peso/zeta_function
-       !
-       call build_sector(isector,H)
-       !
-       do i=1,idim
-          m=H%map(i)
-          ib = bdecomp(m,2*Ns)
-          !
-          if(ed_type=='d')then
-             gs_weight=peso*gsvec(i)**2
-          elseif(ed_type=='c')then
-             gs_weight=peso*abs(gscvec(i))**2
-          endif
-          !
-          !Get operators:
-          do iorb=1,Norb
-             nup(iorb)= dble(ib(iorb))
-             ndw(iorb)= dble(ib(iorb+Ns))
-          enddo
-          !
-          !start evaluating the Tr(H_loc) to estimate potential energy
-          !
-          !LOCAL ENERGY
-          ed_Eknot = ed_Eknot + dot_product(eloc(1,:),nup)*gs_weight + dot_product(eloc(Nspin,:),ndw)*gs_weight
-          !==> HYBRIDIZATION TERMS I: same or different orbitals, same spins.
-          do iorb=1,Norb
-             do jorb=1,Norb
-                !SPIN UP
-                if((ib(iorb)==0).AND.(ib(jorb)==1))then
-                   call c(jorb,m,k1,sg1)
-                   call cdg(iorb,k1,k2,sg2)
-                   j=binary_search(H%map,k2)
-                   ed_Eknot = ed_Eknot + impHloc(1,1,iorb,jorb)*sg1*sg2*gs_weight
-                endif
-                !SPIN DW
-                if((ib(iorb+Ns)==0).AND.(ib(jorb+Ns)==1))then
-                   call c(jorb+Ns,m,k1,sg1)
-                   call cdg(iorb+Ns,k1,k2,sg2)
-                   j=binary_search(H%map,k2)
-                   ed_Eknot = ed_Eknot + impHloc(Nspin,Nspin,iorb,jorb)*sg1*sg2*gs_weight
-                endif
-             enddo
-          enddo
-          !==> HYBRIDIZATION TERMS II: same or different orbitals, opposite spins.
-          if(ed_mode=="nonsu2")then
-             do iorb=1,Norb
-                do jorb=1,Norb
-                   !UP-DW
-                   if((impHloc(1,Nspin,iorb,jorb)/=zero).AND.(ib(iorb)==0).AND.(ib(jorb+Ns)==1))then
-                      call c(jorb+Ns,m,k1,sg1)
-                      call cdg(iorb,k1,k2,sg2)
-                      j=binary_search(H%map,k2)
-                      ed_Eknot = ed_Eknot + impHloc(1,Nspin,iorb,jorb)*sg1*sg2*gs_weight
-                   endif
-                   !DW-UP
-                   if((impHloc(Nspin,1,iorb,jorb)/=zero).AND.(ib(iorb+Ns)==0).AND.(ib(jorb)==1))then
-                      call c(jorb,m,k1,sg1)
-                      call cdg(iorb+Ns,k1,k2,sg2)
-                      j=binary_search(H%map,k2)
-                      ed_Eknot = ed_Eknot + impHloc(Nspin,1,iorb,jorb)*sg1*sg2*gs_weight
-                   endif
-                enddo
-             enddo
-          endif
-          !
-          !DENSITY-DENSITY INTERACTION: SAME ORBITAL, OPPOSITE SPINS
-          !Euloc=\sum=i U_i*(n_u*n_d)_i
-          !ed_Epot = ed_Epot + dot_product(uloc,nup*ndw)*gs_weight
-          do iorb=1,Norb
-             ed_Epot = ed_Epot + Uloc(iorb)*nup(iorb)*ndw(iorb)*gs_weight
-          enddo
-          !
-          !DENSITY-DENSITY INTERACTION: DIFFERENT ORBITALS, OPPOSITE SPINS
-          !Eust=\sum_ij Ust*(n_up_i*n_dn_j + n_up_j*n_dn_i)
-          !    "="\sum_ij (Uloc - 2*Jh)*(n_up_i*n_dn_j + n_up_j*n_dn_i)
-          if(Norb>1)then
-             do iorb=1,Norb
-                do jorb=iorb+1,Norb
-                   ed_Epot = ed_Epot + Ust*(nup(iorb)*ndw(jorb) + nup(jorb)*ndw(iorb))*gs_weight
-                   ed_Dust = ed_Dust + (nup(iorb)*ndw(jorb) + nup(jorb)*ndw(iorb))*gs_weight
-                enddo
-             enddo
-          endif
-          !
-          !DENSITY-DENSITY INTERACTION: DIFFERENT ORBITALS, PARALLEL SPINS
-          !Eund = \sum_ij Und*(n_up_i*n_up_j + n_dn_i*n_dn_j)
-          !    "="\sum_ij (Ust-Jh)*(n_up_i*n_up_j + n_dn_i*n_dn_j)
-          !    "="\sum_ij (Uloc-3*Jh)*(n_up_i*n_up_j + n_dn_i*n_dn_j)
-          if(Norb>1)then
-             do iorb=1,Norb
-                do jorb=iorb+1,Norb
-                   ed_Epot = ed_Epot + (Ust-Jh)*(nup(iorb)*nup(jorb) + ndw(iorb)*ndw(jorb))*gs_weight
-                   ed_Dund = ed_Dund + (nup(iorb)*nup(jorb) + ndw(iorb)*ndw(jorb))*gs_weight
-                enddo
-             enddo
-          endif
-          !
-          !SPIN-EXCHANGE (S-E) TERMS
-          !S-E: Jh *( c^+_iorb_up c^+_jorb_dw c_iorb_dw c_jorb_up )  (i.ne.j) 
-          if(Norb>1.AND.Jhflag)then
-             do iorb=1,Norb
-                do jorb=1,Norb
-                   Jcondition=((iorb/=jorb).AND.&
-                        (ib(jorb)==1)      .AND.&
-                        (ib(iorb+Ns)==1)   .AND.&
-                        (ib(jorb+Ns)==0)   .AND.&
-                        (ib(iorb)==0))
-                   if(Jcondition)then
-                      call c(jorb,m,k1,sg1)
-                      call c(iorb+Ns,k1,k2,sg2)
-                      call cdg(jorb+Ns,k2,k3,sg3)
-                      call cdg(iorb,k3,k4,sg4)
-                      j=binary_search(H%map,k4)
-                      ed_Epot = ed_Epot + Jh*sg1*sg2*sg3*sg4*gs_weight
-                      ed_Dse  = ed_Dse  + sg1*sg2*sg3*sg4*gs_weight
-                   endif
-                enddo
-             enddo
-          endif
-          !
-          !PAIR-HOPPING (P-H) TERMS
-          !P-H: J c^+_iorb_up c^+_iorb_dw   c_jorb_dw   c_jorb_up  (i.ne.j) 
-          !P-H: J c^+_{iorb}  c^+_{iorb+Ns} c_{jorb+Ns} c_{jorb}
-          if(Norb>1.AND.Jhflag)then
-             do iorb=1,Norb
-                do jorb=1,Norb
-                   Jcondition=((iorb/=jorb).AND.&
-                        (ib(jorb)==1)      .AND.&
-                        (ib(jorb+Ns)==1)   .AND.&
-                        (ib(iorb+Ns)==0)   .AND.&
-                        (ib(iorb)==0))
-                   if(Jcondition)then
-                      call c(jorb,m,k1,sg1)
-                      call c(jorb+Ns,k1,k2,sg2)
-                      call cdg(iorb+Ns,k2,k3,sg3)
-                      call cdg(iorb,k3,k4,sg4)
-                      j=binary_search(H%map,k4)
-                      ed_Epot = ed_Epot + Jh*sg1*sg2*sg3*sg4*gs_weight
-                      ed_Dph  = ed_Dph  + sg1*sg2*sg3*sg4*gs_weight
-                   endif
-                enddo
-             enddo
-          endif
-          !
-          !HARTREE-TERMS CONTRIBUTION:
-          if(hfmode)then
-             !ed_Ehartree=ed_Ehartree - 0.5d0*dot_product(uloc,nup+ndw)*gs_weight + 0.25d0*sum(uloc)*gs_weight
-             do iorb=1,Norb
-                ed_Ehartree=ed_Ehartree - 0.5d0*uloc(iorb)*(nup(iorb)+ndw(iorb))*gs_weight + 0.25d0*uloc(iorb)*gs_weight
-             enddo
-             if(Norb>1)then
-                do iorb=1,Norb
-                   do jorb=iorb+1,Norb
-                      ed_Ehartree=ed_Ehartree - 0.5d0*Ust*(nup(iorb)+ndw(iorb)+nup(jorb)+ndw(jorb))*gs_weight + 0.25d0*Ust*gs_weight
-                      ed_Ehartree=ed_Ehartree - 0.5d0*(Ust-Jh)*(nup(iorb)+ndw(iorb)+nup(jorb)+ndw(jorb))*gs_weight + 0.25d0*(Ust-Jh)*gs_weight
-                   enddo
-                enddo
-             endif
-          endif
-       enddo
-       if(associated(gsvec))nullify(gsvec)
-       if(associated(gscvec))nullify(gscvec)
-       deallocate(H%map)
-    enddo
-    ed_Epot = ed_Epot + ed_Ehartree
-    !
-    if(ED_MPI_ID==0)then
-       if(ed_verbose<0)then
-          write(LOGfile,"(A,10f18.12)")"<Hint>  =",ed_Epot
-          write(LOGfile,"(A,10f18.12)")"<V>     =",ed_Epot-ed_Ehartree
-          write(LOGfile,"(A,10f18.12)")"<E0>    =",ed_Eknot
-          write(LOGfile,"(A,10f18.12)")"<Ehf>   =",ed_Ehartree    
-          write(LOGfile,"(A,10f18.12)")"Dust    =",ed_Dust
-          write(LOGfile,"(A,10f18.12)")"Dund    =",ed_Dund
-          write(LOGfile,"(A,10f18.12)")"Dse     =",ed_Dse
-          write(LOGfile,"(A,10f18.12)")"Dph     =",ed_Dph
-       endif
-    endif
-    !
-    !
-    call write_energy_info()
-    call write_energy()
-  end subroutine local_energy_impurity
-
-
-
-
-
-
-
 
 
 
@@ -1111,22 +867,6 @@ contains
   !+-------------------------------------------------------------------+
   !PURPOSE  : write legend, i.e. info about columns 
   !+-------------------------------------------------------------------+
-  subroutine write_energy_info()
-    integer :: unit
-    unit = free_unit()
-    open(unit,file="energy_info.ed")
-    write(unit,"(A1,90(A14,1X))")"#",&
-         reg(txtfy(1))//"<Hi>",&
-         reg(txtfy(2))//"<V>=<Hi-Ehf>",&
-         reg(txtfy(3))//"<Eloc>",&
-         reg(txtfy(4))//"<Ehf>",&
-         reg(txtfy(5))//"<Dst>",&
-         reg(txtfy(6))//"<Dnd>",&
-         reg(txtfy(7))//"<Dse>",&
-         reg(txtfy(8))//"<Dph>"
-    close(unit)
-  end subroutine write_energy_info
-
   subroutine write_kinetic_info()
     integer :: unit
     unit = free_unit()
@@ -1140,14 +880,6 @@ contains
   !+-------------------------------------------------------------------+
   !PURPOSE  : Write energies to file
   !+-------------------------------------------------------------------+
-  subroutine write_energy()
-    integer :: unit
-    unit = free_unit()
-    open(unit,file="energy_last"//reg(ed_file_suffix)//".ed")
-    write(unit,"(90F15.9)")ed_Epot,ed_Epot-ed_Ehartree,ed_Eknot,ed_Ehartree,ed_Dust,ed_Dund,ed_Dse,ed_Dph
-    close(unit)
-  end subroutine write_energy
-
   subroutine write_kinetic(Ekin)
     real(8) :: Ekin(2)
     integer :: unit

--- a/ED_GLOC.f90
+++ b/ED_GLOC.f90
@@ -2,6 +2,9 @@ module ED_GLOC
   USE ED_INPUT_VARS
   USE ED_VARS_GLOBAL
   USE ED_AUX_FUNX
+  !
+  USE ED_MPI2B
+  !
   USE SF_TIMER
   USE SF_IOTOOLS,   only: reg,txtfy,splot,store_data
   USE SF_LINALG,    only: eye,inv,inv_sym,inv_tridiag,get_tridiag

--- a/ED_GREENS_FUNCTIONS/build_chi_dens.f90
+++ b/ED_GREENS_FUNCTIONS/build_chi_dens.f90
@@ -5,7 +5,7 @@ subroutine build_chi_dens()
   integer :: iorb,jorb
   write(LOGfile,"(A)")"Get impurity dens Chi:"
   do iorb=1,Norb
-     if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_dens_diag_l"//reg(txtfy(iorb))
+     if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_dens_diag_l"//reg(txtfy(iorb))
      select case(ed_type)
      case default
         call lanc_ed_build_densChi_diag_d(iorb)
@@ -18,7 +18,7 @@ subroutine build_chi_dens()
   if(Norb>1)then
      do iorb=1,Norb
         do jorb=iorb+1,Norb
-           if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_dens_offdiag_l"//reg(txtfy(iorb))//reg(txtfy(jorb))
+           if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_dens_offdiag_l"//reg(txtfy(iorb))//reg(txtfy(jorb))
            select case(ed_type)
            case default
               call lanc_ed_build_densChi_offdiag_d(iorb,jorb)
@@ -35,7 +35,7 @@ subroutine build_chi_dens()
      !
      do iorb=1,Norb
         do jorb=1,Norb
-           if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_dens_offdiag_l"//reg(txtfy(iorb))//reg(txtfy(jorb))
+           if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_dens_offdiag_l"//reg(txtfy(iorb))//reg(txtfy(jorb))
            select case(ed_type)
            case default
               call lanc_ed_build_densChi_mix_d(iorb,jorb)
@@ -45,7 +45,7 @@ subroutine build_chi_dens()
         end do
      end do
      !
-     if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_dens_tot"
+     if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_dens_tot"
      select case(ed_type)
      case default
         call lanc_ed_build_densChi_tot_d()
@@ -92,7 +92,7 @@ subroutine lanc_ed_build_densChi_diag_d(iorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      state_e    =  es_return_energy(state_list,izero)
@@ -101,7 +101,7 @@ subroutine lanc_ed_build_densChi_diag_d(iorb)
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
@@ -125,7 +125,7 @@ subroutine lanc_ed_build_densChi_diag_d(iorb)
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_vec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_densChi_diag_d
 
@@ -148,7 +148,7 @@ subroutine lanc_ed_build_densChi_diag_c(iorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      idim      =  getdim(isector)
@@ -158,7 +158,7 @@ subroutine lanc_ed_build_densChi_diag_c(iorb)
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
@@ -182,7 +182,7 @@ subroutine lanc_ed_build_densChi_diag_c(iorb)
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_cvec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_densChi_diag_c
 
@@ -212,7 +212,7 @@ subroutine lanc_ed_build_densChi_offdiag_d(iorb,jorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      ! properties of the ground states
      isector     =  es_return_sector(state_list,izero)
@@ -225,7 +225,7 @@ subroutine lanc_ed_build_densChi_offdiag_d(iorb,jorb)
      call build_sector(isector,HI)
      !
      !build the (N_iorb+N_jorb)|gs> state
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A)")'Apply N_iorb + N_jorb:'
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A)")'Apply N_iorb + N_jorb:'
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
         i=HI%map(m)
@@ -250,7 +250,7 @@ subroutine lanc_ed_build_densChi_offdiag_d(iorb,jorb)
      call add_to_lanczos_densChi(cnorm2,state_e,nitermax,alfa_,beta_,isign,iorb,jorb)
      !
      !build the (N_iorb - xi*N_jorb)|gs> state
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A)")'Apply N_iorb + xi*N_jorb:'
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A)")'Apply N_iorb + xi*N_jorb:'
      cvinit=zero
      do m=1,idim
         i=HI%map(m)
@@ -272,7 +272,7 @@ subroutine lanc_ed_build_densChi_offdiag_d(iorb,jorb)
      call add_to_lanczos_densChi(cnorm2,state_e,nitermax,alfa_,beta_,isign,iorb,jorb)
      !
      !build the (N_iorb + xi*N_jorb)|gs> state
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A)")'Apply N_iorb + xi*N_jorb:'
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A)")'Apply N_iorb + xi*N_jorb:'
      cvinit=zero
      do m=1,idim
         i=HI%map(m)
@@ -297,7 +297,7 @@ subroutine lanc_ed_build_densChi_offdiag_d(iorb,jorb)
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_vec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_densChi_offdiag_d
 
@@ -329,7 +329,7 @@ subroutine lanc_ed_build_densChi_tot_d()
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      state_e    =  es_return_energy(state_list,izero)
@@ -338,7 +338,7 @@ subroutine lanc_ed_build_densChi_tot_d()
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim  
@@ -362,7 +362,7 @@ subroutine lanc_ed_build_densChi_tot_d()
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_vec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_densChi_tot_d
 
@@ -385,7 +385,7 @@ subroutine lanc_ed_build_densChi_tot_c()
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      idim      =  getdim(isector)
@@ -395,7 +395,7 @@ subroutine lanc_ed_build_densChi_tot_c()
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply N:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
@@ -419,7 +419,7 @@ subroutine lanc_ed_build_densChi_tot_c()
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_cvec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_densChi_tot_c
 
@@ -460,7 +460,7 @@ subroutine lanc_ed_build_densChi_mix_d(iorb,jorb)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -572,7 +572,7 @@ subroutine lanc_ed_build_densChi_mix_d(iorb,jorb)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_densChi_mix_d
 

--- a/ED_GREENS_FUNCTIONS/build_chi_pair.f90
+++ b/ED_GREENS_FUNCTIONS/build_chi_pair.f90
@@ -5,7 +5,7 @@ subroutine build_chi_pair()
   integer :: iorb
   write(LOGfile,"(A)")"Get impurity pair Chi:"
   do iorb=1,Norb
-     if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_pair_l"//reg(txtfy(iorb))
+     if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_pair_l"//reg(txtfy(iorb))
      select case(ed_type)
      case default
         call lanc_ed_build_pairChi_d(iorb)
@@ -43,7 +43,7 @@ subroutine lanc_ed_build_pairChi_d(iorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector    =  es_return_sector(state_list,izero)
      state_e    =  es_return_energy(state_list,izero)
@@ -54,7 +54,7 @@ subroutine lanc_ed_build_pairChi_d(iorb)
      
      call build_sector(isector,HI)
      !Build the C_{iorb,up}C_{iorb,dw}|eigvec> 
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply C_{iorb,up}C_{iorb,dw}:',getsz(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply C_{iorb,up}C_{iorb,dw}:',getsz(isector)
      allocate(vvinit(idim))
      vvinit=0.d0
      do m=1,idim
@@ -75,7 +75,7 @@ subroutine lanc_ed_build_pairChi_d(iorb)
      call add_to_lanczos_pairChi(norm0,state_e,nitermax,alfa_,beta_,isign,iorb)
      deallocate(vvinit)
      !Build the CDG_{iorb,dw}CDG_{iorb,up}|eigvec> 
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply CDG_{iorb,dw}CDG_{iorb,up}:',getsz(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply CDG_{iorb,dw}CDG_{iorb,up}:',getsz(isector)
      allocate(vvinit(idim))
      vvinit=0.d0
      do m=1,idim
@@ -99,7 +99,7 @@ subroutine lanc_ed_build_pairChi_d(iorb)
      deallocate(HI%map)
      nullify(state_vec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_pairChi_d
 
@@ -121,7 +121,7 @@ subroutine lanc_ed_build_pairChi_c(iorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector    =  es_return_sector(state_list,izero)
      idim       =  getdim(isector)
@@ -133,7 +133,7 @@ subroutine lanc_ed_build_pairChi_c(iorb)
 
      call build_sector(isector,HI)
      !Build the C_{iorb,up}C_{iorb,dw}|eigvec> 
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply C_{iorb,up}C_{iorb,dw}:',getsz(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply C_{iorb,up}C_{iorb,dw}:',getsz(isector)
      allocate(vvinit(idim))
      vvinit=0.d0
      do m=1,idim
@@ -154,7 +154,7 @@ subroutine lanc_ed_build_pairChi_c(iorb)
      call add_to_lanczos_pairChi(norm0,state_e,nitermax,alfa_,beta_,isign,iorb)
      deallocate(vvinit)
      !Build the CDG_{iorb,dw}CDG_{iorb,up}|eigvec> 
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply CDG_{iorb,dw}CDG_{iorb,up}:',getsz(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply CDG_{iorb,dw}CDG_{iorb,up}:',getsz(isector)
      allocate(vvinit(idim))
      vvinit=0.d0
      do m=1,idim
@@ -178,7 +178,7 @@ subroutine lanc_ed_build_pairChi_c(iorb)
      deallocate(HI%map)
      nullify(state_cvec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_pairChi_c
 

--- a/ED_GREENS_FUNCTIONS/build_chi_spin.f90
+++ b/ED_GREENS_FUNCTIONS/build_chi_spin.f90
@@ -5,7 +5,7 @@ subroutine build_chi_spin()
   integer :: iorb
   write(LOGfile,"(A)")"Get impurity spin Chi:"
   do iorb=1,Norb
-     if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_spin_l"//reg(txtfy(iorb))
+     if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_spin_l"//reg(txtfy(iorb))
      select case(ed_type)
      case default
         call lanc_ed_build_spinChi_d(iorb)
@@ -14,7 +14,7 @@ subroutine build_chi_spin()
      end select
   enddo
   if(Norb>1)then
-     if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get Chi_spin_tot"
+     if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get Chi_spin_tot"
      select case(ed_type)
      case default
         call lanc_ed_build_spinChi_tot_d()
@@ -55,7 +55,7 @@ subroutine lanc_ed_build_spinChi_d(iorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      state_e    =  es_return_energy(state_list,izero)
@@ -64,7 +64,7 @@ subroutine lanc_ed_build_spinChi_d(iorb)
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
@@ -89,7 +89,7 @@ subroutine lanc_ed_build_spinChi_d(iorb)
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_vec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_spinChi_d
 
@@ -111,7 +111,7 @@ subroutine lanc_ed_build_spinChi_c(iorb)
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      idim      =  getdim(isector)
@@ -121,7 +121,7 @@ subroutine lanc_ed_build_spinChi_c(iorb)
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
@@ -146,7 +146,7 @@ subroutine lanc_ed_build_spinChi_c(iorb)
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_cvec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_spinChi_c
 
@@ -180,7 +180,7 @@ subroutine lanc_ed_build_spinChi_tot_d()
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      state_e    =  es_return_energy(state_list,izero)
@@ -189,7 +189,7 @@ subroutine lanc_ed_build_spinChi_tot_d()
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim  
@@ -214,7 +214,7 @@ subroutine lanc_ed_build_spinChi_tot_d()
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_vec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_spinChi_tot_d
 
@@ -236,7 +236,7 @@ subroutine lanc_ed_build_spinChi_tot_c()
   !
   numstates=state_list%size
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do izero=1,numstates
      isector     =  es_return_sector(state_list,izero)
      idim       =  getdim(isector)
@@ -246,7 +246,7 @@ subroutine lanc_ed_build_spinChi_tot_c()
      if(abs(norm0-1.d0)>1.d-9)stop "GS is not normalized"
      idim  = getdim(isector)
      allocate(vvinit(idim))
-     if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
+     if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")'Apply Sz:',getnup(isector),getndw(isector)
      call build_sector(isector,HI)
      vvinit=0.d0
      do m=1,idim                     !loop over |gs> components m
@@ -271,7 +271,7 @@ subroutine lanc_ed_build_spinChi_tot_c()
      if(spH0%status)call sp_delete_matrix(spH0)
      nullify(state_cvec)
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_ed_build_spinChi_tot_c
 

--- a/ED_GREENS_FUNCTIONS/build_gf_nonsu2.f90
+++ b/ED_GREENS_FUNCTIONS/build_gf_nonsu2.f90
@@ -22,7 +22,7 @@ subroutine build_gf_nonsu2()
      !Here we evaluate the same orbital, same spin GF: G_{aa}^{ss}(z)
      do ispin=1,Nspin
         do iorb=1,Norb
-           if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(ispin))
+           if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(ispin))
            select case(ed_type)
            case default
               call lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
@@ -37,7 +37,7 @@ subroutine build_gf_nonsu2()
            do iorb=1,Norb
               do jorb=1,Norb
                  if((ispin.ne.jspin).and.(iorb.eq.jorb)) then
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -73,7 +73,7 @@ subroutine build_gf_nonsu2()
      !Here we evaluate the same orbital, same spin GF: G_{aa}^{ss}(z)
      do ispin=1,Nspin
         do iorb=1,Norb
-           if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(ispin))
+           if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(ispin))
            select case(ed_type)
            case default
               call lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
@@ -89,7 +89,7 @@ subroutine build_gf_nonsu2()
            do iorb=1,Norb
               do jorb=1,Norb
                  if((ispin.ne.jspin).and.(iorb.eq.jorb)) then
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -126,7 +126,7 @@ subroutine build_gf_nonsu2()
            do iorb=1,Norb
               do jorb=1,Norb
                  if((ispin.eq.jspin).and.(iorb.ne.jorb)) then
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -163,7 +163,7 @@ subroutine build_gf_nonsu2()
            do iorb=1,Norb
               do jorb=1,Norb
                  if((ispin.ne.jspin).and.(iorb.ne.jorb)) then
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -199,7 +199,7 @@ subroutine build_gf_nonsu2()
      !Here we evaluate the same orbital, same spin GF: G_{aa}^{ss}(z)
      do ispin=1,Nspin
         do iorb=1,Norb
-           if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(ispin))
+           if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(ispin))
            select case(ed_type)
            case default
               call lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
@@ -216,7 +216,7 @@ subroutine build_gf_nonsu2()
               do jorb=1,Norb
                  if((ispin.ne.jspin).and.(iorb.eq.jorb)) then
                     if((dmft_bath%mask(ispin,jspin,iorb,jorb,1).eqv. .false.).and.(dmft_bath%mask(ispin,jspin,iorb,jorb,2).eqv. .false.))cycle
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -255,7 +255,7 @@ subroutine build_gf_nonsu2()
               do jorb=1,Norb
                  if((ispin.eq.jspin).and.(iorb.ne.jorb)) then
                     if((dmft_bath%mask(ispin,jspin,iorb,jorb,1).eqv. .false.).and.(dmft_bath%mask(ispin,jspin,iorb,jorb,2).eqv. .false.))cycle
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -294,7 +294,7 @@ subroutine build_gf_nonsu2()
               do jorb=1,Norb
                  if((ispin.ne.jspin).and.(iorb.ne.jorb)) then
                     if((dmft_bath%mask(ispin,jspin,iorb,jorb,1).eqv. .false.).and.(dmft_bath%mask(ispin,jspin,iorb,jorb,2).eqv. .false.))cycle
-                    if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+                    if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
                     select case(ed_type)
                     case default
                        call lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
@@ -378,7 +378,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -392,7 +392,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ) !note that here you are doing twice the map building...
         vvinit=0d0
@@ -421,7 +421,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -450,7 +450,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_d(iorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_d
 
@@ -477,7 +477,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d(iorb,jorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -493,7 +493,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -531,7 +531,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -570,7 +570,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -608,7 +608,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -646,7 +646,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d(iorb,jorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_d
 
@@ -673,7 +673,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d(iorb,ispin,jspin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector     =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -689,7 +689,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d(iorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -727,7 +727,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d(iorb,ispin,jspin)
      jsector = getCsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -766,7 +766,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d(iorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -804,7 +804,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d(iorb,ispin,jspin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -842,7 +842,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d(iorb,ispin,jspin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_d
 
@@ -869,7 +869,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector     =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -885,7 +885,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -923,7 +923,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
      jsector = getCsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -962,7 +962,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -1000,7 +1000,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -1038,7 +1038,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d(iorb,jorb,ispin,jspin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_d
 
@@ -1085,7 +1085,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_c(iorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -1099,7 +1099,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_c(iorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ) !note that here you are doing twice the map building...
         vvinit=0d0
@@ -1128,7 +1128,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_c(iorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1157,7 +1157,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_c(iorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_diagOrb_diagSpin_c
 
@@ -1183,7 +1183,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c(iorb,jorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector     =  es_return_sector(state_list,istate)
      state_e     =  es_return_energy(state_list,istate)
@@ -1199,7 +1199,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1237,7 +1237,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1276,7 +1276,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=zero
@@ -1314,7 +1314,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=zero
@@ -1352,7 +1352,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c(iorb,jorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_mixOrb_diagSpin_c
 
@@ -1378,7 +1378,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c(iorb,ispin,jspin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector     =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -1394,7 +1394,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c(iorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1432,7 +1432,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c(iorb,ispin,jspin)
      jsector = getCsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1471,7 +1471,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c(iorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=zero
@@ -1509,7 +1509,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c(iorb,ispin,jspin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=zero
@@ -1547,7 +1547,7 @@ subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c(iorb,ispin,jspin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_diagOrb_mixSpin_c
 
@@ -1573,7 +1573,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c(iorb,jorb,ispin,jspin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector     =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -1589,7 +1589,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c(iorb,jorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1627,7 +1627,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c(iorb,jorb,ispin,jspin)
      jsector = getCsector(ispin,isector) !this is the same sector I'd get using getCDGsector(JSPIN,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -1666,7 +1666,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c(iorb,jorb,ispin,jspin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' add particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=zero
@@ -1704,7 +1704,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c(iorb,jorb,ispin,jspin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,I3)")' del particle:',getn(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=zero
@@ -1742,7 +1742,7 @@ subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c(iorb,jorb,ispin,jspin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_nonsu2_mixOrb_mixSpin_c
 

--- a/ED_GREENS_FUNCTIONS/build_gf_normal.f90
+++ b/ED_GREENS_FUNCTIONS/build_gf_normal.f90
@@ -12,7 +12,7 @@ subroutine build_gf_normal()
   !
   do ispin=1,Nspin
      do iorb=1,Norb
-        if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))
+        if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))
         select case(ed_type)
         case default
            call lanc_build_gf_normal_d(iorb,ispin)
@@ -26,7 +26,7 @@ subroutine build_gf_normal()
      do ispin=1,Nspin
         do iorb=1,Norb
            do jorb=iorb+1,Norb
-              if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")&
+              if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")&
                    "Get G_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))
               select case(ed_type)
               case default
@@ -55,7 +55,7 @@ subroutine build_gf_normal()
         do iorb=1,Norb
            do jorb=iorb+1,Norb
               if((dmft_bath%mask(ispin,ispin,iorb,jorb,1).eqv. .true.).or.(dmft_bath%mask(ispin,ispin,iorb,jorb,2).eqv. .true.))then
-                 if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")&
+                 if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")&
                       "Get G_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))
                  select case(ed_type)
                  case default
@@ -208,7 +208,7 @@ subroutine lanc_build_gf_normal_d(iorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -221,7 +221,7 @@ subroutine lanc_build_gf_normal_d(iorb,ispin)
      !ADD ONE PARTICLE:
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")' add particle:',getnup(jsector),getndw(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")' add particle:',getnup(jsector),getndw(jsector)
         jdim  = getdim(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
@@ -250,7 +250,7 @@ subroutine lanc_build_gf_normal_d(iorb,ispin)
      !REMOVE ONE PARTICLE:
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")' del particle:',getnup(jsector),getndw(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")' del particle:',getnup(jsector),getndw(jsector)
         jdim  = getdim(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
@@ -280,7 +280,7 @@ subroutine lanc_build_gf_normal_d(iorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_normal_d
 
@@ -308,7 +308,7 @@ subroutine lanc_build_gf_normal_c(iorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -321,7 +321,7 @@ subroutine lanc_build_gf_normal_c(iorb,ispin)
      !ADD ONE PARTICLE:
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3)")' add particle:',getnup(jsector),getndw(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3)")' add particle:',getnup(jsector),getndw(jsector)
         jdim  = getdim(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ) !note that here you are doing twice the map building...
@@ -351,7 +351,7 @@ subroutine lanc_build_gf_normal_c(iorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A,2I3,I15)")' del particle:',&
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A,2I3,I15)")' del particle:',&
              getnup(jsector),getndw(jsector),jdim
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
@@ -381,7 +381,7 @@ subroutine lanc_build_gf_normal_c(iorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_normal_c
 
@@ -414,7 +414,7 @@ subroutine lanc_build_gf_normal_mix_d(iorb,jorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -430,7 +430,7 @@ subroutine lanc_build_gf_normal_mix_d(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -468,7 +468,7 @@ subroutine lanc_build_gf_normal_mix_d(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -506,7 +506,7 @@ subroutine lanc_build_gf_normal_mix_d(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -544,7 +544,7 @@ subroutine lanc_build_gf_normal_mix_d(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -582,7 +582,7 @@ subroutine lanc_build_gf_normal_mix_d(iorb,jorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_normal_mix_d
 
@@ -612,7 +612,7 @@ subroutine lanc_build_gf_normal_mix_c(iorb,jorb,ispin)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
      state_e    =  es_return_energy(state_list,istate)
@@ -628,7 +628,7 @@ subroutine lanc_build_gf_normal_mix_c(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -666,7 +666,7 @@ subroutine lanc_build_gf_normal_mix_c(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -704,7 +704,7 @@ subroutine lanc_build_gf_normal_mix_c(iorb,jorb,ispin)
      jsector = getCDGsector(ispin,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' add particle:',getnup(jsector),getndw(jsector),jdim
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -742,7 +742,7 @@ subroutine lanc_build_gf_normal_mix_c(iorb,jorb,ispin)
      jsector = getCsector(ispin,isector)
      if(jsector/=0)then
         jdim   = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
+        if(ed_verbose<1.AND.MPI_MASTER)write(*,"(A,2I3,I15)")' del particle:',getnup(jsector),getndw(jsector),jdim
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=zero
@@ -780,7 +780,7 @@ subroutine lanc_build_gf_normal_mix_c(iorb,jorb,ispin)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_normal_mix_c
 

--- a/ED_GREENS_FUNCTIONS/build_gf_superc.f90
+++ b/ED_GREENS_FUNCTIONS/build_gf_superc.f90
@@ -26,7 +26,7 @@ subroutine build_gf_superc()
   do iorb=1,Norb
      auxGmats=zero
      auxGreal=zero
-     if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"Get G&F_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))
+     if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")"Get G&F_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))
      call lanc_build_gf_superc_d(iorb)
      !
      impGmats(ispin,ispin,iorb,iorb,:) = auxGmats(1,:) !this is G_{iorb,iorb} = G_{up,up;iorb,iorb}
@@ -53,7 +53,7 @@ subroutine build_gf_superc()
   if(bath_type=='hybrid')then
      do iorb=1,Norb
         do jorb=iorb+1,Norb
-           if(ed_verbose<3.AND.ED_MPI_ID==0)write(LOGfile,"(A)")&
+           if(ed_verbose<3.AND.MPI_MASTER)write(LOGfile,"(A)")&
                 "Get G_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))
            call lanc_build_gf_superc_mix_d(iorb,jorb)
            impGmats(ispin,ispin,iorb,jorb,:) = auxGmats(3,:)
@@ -103,7 +103,7 @@ subroutine lanc_build_gf_superc_d(iorb)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   !
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
@@ -118,7 +118,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      jsector = getCDGsector(1,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A23,I3)")'apply c^+_up:',getsz(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A23,I3)")'apply c^+_up:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -147,7 +147,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      jsector = getCsector(1,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A23,I3)")'apply c_up:',getsz(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A23,I3)")'apply c_up:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -179,7 +179,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      jsector = getCsector(2,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)&
+        if(ed_verbose<1.AND.MPI_MASTER)&
              write(LOGfile,"(A23,I3)")'apply c_dw:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
@@ -209,7 +209,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      jsector = getCDGsector(2,isector)
      if(jsector/=0)then 
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)&
+        if(ed_verbose<1.AND.MPI_MASTER)&
              write(LOGfile,"(A23,I3)")'apply c^+_dw:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ) !note that here you are doing twice the map building...
@@ -244,7 +244,7 @@ subroutine lanc_build_gf_superc_d(iorb)
         jsz   = isz+1
         jsector = getsector(jsz,1)
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A23,I3)")'apply c^+_up + c_dw:',getsz(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A23,I3)")'apply c^+_up + c_dw:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -284,7 +284,7 @@ subroutine lanc_build_gf_superc_d(iorb)
         jsz   = isz-1
         jsector = getsector(jsz,1)
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)&
+        if(ed_verbose<1.AND.MPI_MASTER)&
              write(LOGfile,"(A23,I3)")'apply c_up + c^+_dw:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
@@ -328,7 +328,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      !    jsz   = isz+1
      !    jsector = getsector(jsz,1)
      !    jdim  = getdim(jsector)
-     !    if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A23,I3)")'apply c^+_up + xi*c_dw:',getsz(jsector)
+     !    if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A23,I3)")'apply c^+_up + xi*c_dw:',getsz(jsector)
      !    allocate(cvinit(jdim))
      !    call build_sector(jsector,HJ)
      !    cvinit=0.d0
@@ -368,7 +368,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      !    jsz   = isz-1
      !    jsector = getsector(jsz,1)
      !    jdim  = getdim(jsector)
-     !    if(ed_verbose<1.AND.ED_MPI_ID==0)&
+     !    if(ed_verbose<1.AND.MPI_MASTER)&
      !         write(LOGfile,"(A23,I3)")'apply c_up - xi*c^+_dw:',getsz(jsector)
      !    allocate(cvinit(jdim))
      !    call build_sector(jsector,HJ)
@@ -408,7 +408,7 @@ subroutine lanc_build_gf_superc_d(iorb)
      deallocate(HI%map)
      !
   enddo
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_superc_d
 
@@ -440,7 +440,7 @@ subroutine lanc_build_gf_superc_mix_d(iorb,jorb)
   !
   numstates=state_list%size
   !   
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call start_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call start_timer
   !
   do istate=1,numstates
      isector    =  es_return_sector(state_list,istate)
@@ -458,7 +458,7 @@ subroutine lanc_build_gf_superc_mix_d(iorb,jorb)
         jsz   = isz+1
         jsector = getsector(jsz,1)
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A23,I3)")'apply c^+_{up,iorb} + c_{dw,jorb}:',getsz(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A23,I3)")'apply c^+_{up,iorb} + c_{dw,jorb}:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
         vvinit=0.d0
@@ -498,7 +498,7 @@ subroutine lanc_build_gf_superc_mix_d(iorb,jorb)
         jsz   = isz-1
         jsector = getsector(jsz,1)
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)&
+        if(ed_verbose<1.AND.MPI_MASTER)&
              write(LOGfile,"(A23,I3)")'apply c_{up,iorb} + c^+_{dw,jorb}:',getsz(jsector)
         allocate(vvinit(jdim))
         call build_sector(jsector,HJ)
@@ -540,7 +540,7 @@ subroutine lanc_build_gf_superc_mix_d(iorb,jorb)
         jsz   = isz+1
         jsector = getsector(jsz,1)
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)write(LOGfile,"(A23,I3)")'apply c^+_{up,iorb} + xi*c_{dw,horb}:',getsz(jsector)
+        if(ed_verbose<1.AND.MPI_MASTER)write(LOGfile,"(A23,I3)")'apply c^+_{up,iorb} + xi*c_{dw,horb}:',getsz(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
         cvinit=0.d0
@@ -580,7 +580,7 @@ subroutine lanc_build_gf_superc_mix_d(iorb,jorb)
         jsz   = isz-1
         jsector = getsector(jsz,1)
         jdim  = getdim(jsector)
-        if(ed_verbose<1.AND.ED_MPI_ID==0)&
+        if(ed_verbose<1.AND.MPI_MASTER)&
              write(LOGfile,"(A23,I3)")'apply c_{up,iorb} - xi*c^+_{dw,jorb}:',getsz(jsector)
         allocate(cvinit(jdim))
         call build_sector(jsector,HJ)
@@ -620,7 +620,7 @@ subroutine lanc_build_gf_superc_mix_d(iorb,jorb)
      !
   enddo
   !
-  if(ed_verbose<3.AND.ED_MPI_ID==0)call stop_timer
+  if(ed_verbose<3.AND.MPI_MASTER)call stop_timer
   deallocate(alfa_,beta_)
 end subroutine lanc_build_gf_superc_mix_d
 

--- a/ED_IO.f90
+++ b/ED_IO.f90
@@ -1658,11 +1658,11 @@ contains
     !
     if(ed_verbose<1) then
        Tr=zero;Tr=trace(dm_)
-       if(ED_MPI_ID==0)write(LOGfile,'(A25,6F15.7)') 'test #1: Tr[rho]:    ',real(Tr),aimag(Tr)
+       write(LOGfile,'(A25,6F15.7)') 'test #1: Tr[rho]:    ',real(Tr),aimag(Tr)
        Tr=zero;Tr=trace(matmul(dm_,dm_))
-       if(ED_MPI_ID==0)write(LOGfile,'(A25,6F15.7)') 'test #2: Tr[rho^2]:  ',real(Tr),aimag(Tr)
+       write(LOGfile,'(A25,6F15.7)') 'test #2: Tr[rho^2]:  ',real(Tr),aimag(Tr)
        Tr=zero;Tr=sum(dm_eig_)
-       if(ED_MPI_ID==0)write(LOGfile,'(A25,6F15.7)') 'test #3: Tr[rot(rho)]:',Tr
+       write(LOGfile,'(A25,6F15.7)') 'test #3: Tr[rot(rho)]:',Tr
     endif
   end subroutine ed_get_density_matrix
 

--- a/ED_IO/print_PolesWeights.f90
+++ b/ED_IO/print_PolesWeights.f90
@@ -30,20 +30,18 @@ subroutine print_poles_weights_normal
   if(l/=totNorb)stop "print_gf_normal error counting the orbitals"
   !!
   !Print the impurity functions:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        do isign=1,2
-           do i=1,lanc_nGFiter
-              write(unit(1),"(6(F20.12,1x))")(GFpoles(ispin,ispin,iorb,jorb,isign,i),GFweights(ispin,ispin,iorb,jorb,isign,i),ispin=1,Nspin)
-           enddo
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     do isign=1,2
+        do i=1,lanc_nGFiter
+           write(unit(1),"(6(F20.12,1x))")(GFpoles(ispin,ispin,iorb,jorb,isign,i),GFweights(ispin,ispin,iorb,jorb,isign,i),ispin=1,Nspin)
         enddo
-        call close_units()
      enddo
-  endif
+     call close_units()
+  enddo
   !
 contains
   !
@@ -90,20 +88,18 @@ subroutine print_poles_weights_superc
   if(l/=totNorb)stop "print_gf_superc error counting the orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        do isign=1,2
-           do i=1,lanc_nGFiter
-              write(unit(1),"(6(F20.12,1x))")(GFpoles(ispin,ispin,iorb,jorb,isign,i),GFweights(ispin,ispin,iorb,jorb,isign,i),ispin=1,Nspin)
-           enddo
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     do isign=1,2
+        do i=1,lanc_nGFiter
+           write(unit(1),"(6(F20.12,1x))")(GFpoles(ispin,ispin,iorb,jorb,isign,i),GFweights(ispin,ispin,iorb,jorb,isign,i),ispin=1,Nspin)
         enddo
-        call close_units
      enddo
-  endif
+     call close_units
+  enddo
   !
 contains
   subroutine open_units(string)
@@ -198,25 +194,23 @@ subroutine print_poles_weights_nonsu2
   if(l/=totNso)stop "print_gf_nonsu2 error counting the spin-orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNso
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        ispin=getIspin(l)
-        jspin=getJspin(l)
-        !
-        suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
-        call open_units(reg(suffix))
-        !
-        do isign=1,2
-           do i=1,lanc_nGFiter
-              write(unit(1),"(2(F20.12,1x))")GFpoles(ispin,jspin,iorb,iorb,isign,i),GFweights(ispin,jspin,iorb,iorb,isign,i)
-           enddo
+  do l=1,totNso
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     ispin=getIspin(l)
+     jspin=getJspin(l)
+     !
+     suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+     call open_units(reg(suffix))
+     !
+     do isign=1,2
+        do i=1,lanc_nGFiter
+           write(unit(1),"(2(F20.12,1x))")GFpoles(ispin,jspin,iorb,iorb,isign,i),GFweights(ispin,jspin,iorb,iorb,isign,i)
         enddo
-        !
-        call close_units()
      enddo
-  endif
+     !
+     call close_units()
+  enddo
   !
 contains
   subroutine open_units(string)

--- a/ED_IO/print_impChi.f90
+++ b/ED_IO/print_impChi.f90
@@ -4,44 +4,42 @@
 subroutine print_chi_spin
   integer                               :: i,iorb
   integer                               :: unit(3)
-  if(ED_MPI_ID==0)then
-     do iorb=1,Norb
-        unit=free_units(3)
-        open(unit(1),file="spinChi_orb"//reg(txtfy(iorb))//"_tau"//reg(ed_file_suffix)//".ed")
-        open(unit(2),file="spinChi_orb"//reg(txtfy(iorb))//"_realw"//reg(ed_file_suffix)//".ed")
-        open(unit(3),file="spinChi_orb"//reg(txtfy(iorb))//"_iw"//reg(ed_file_suffix)//".ed")
-        do i=0,Ltau
-           write(unit(1),*)tau(i),spinChi_tau(iorb,i)
-        enddo
-        do i=1,Lreal
-           if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(spinChi_w(iorb,i)),dreal(spinChi_w(iorb,i))
-        enddo
-        do i=0,Lmats
-           write(unit(3),*)vm(i),dimag(spinChi_iv(iorb,i)),dreal(spinChi_iv(iorb,i))
-        enddo
-        do i=1,3
-           close(unit(i))
-        enddo
+  do iorb=1,Norb
+     unit=free_units(3)
+     open(unit(1),file="spinChi_orb"//reg(txtfy(iorb))//"_tau"//reg(ed_file_suffix)//".ed")
+     open(unit(2),file="spinChi_orb"//reg(txtfy(iorb))//"_realw"//reg(ed_file_suffix)//".ed")
+     open(unit(3),file="spinChi_orb"//reg(txtfy(iorb))//"_iw"//reg(ed_file_suffix)//".ed")
+     do i=0,Ltau
+        write(unit(1),*)tau(i),spinChi_tau(iorb,i)
      enddo
-     if(Norb>1)then
-        iorb=Norb+1
-        unit=free_units(3)
-        open(unit(1),file="spinChi_tot"//reg(txtfy(iorb))//"_tau"//reg(ed_file_suffix)//".ed")
-        open(unit(2),file="spinChi_tot"//reg(txtfy(iorb))//"_realw"//reg(ed_file_suffix)//".ed")
-        open(unit(3),file="spinChi_tot"//reg(txtfy(iorb))//"_iw"//reg(ed_file_suffix)//".ed")
-        do i=0,Ltau
-           write(unit(1),*)tau(i),spinChi_tau(iorb,i)
-        enddo
-        do i=1,Lreal
-           if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(spinChi_w(iorb,i)),dreal(spinChi_w(iorb,i))
-        enddo
-        do i=0,Lmats
-           write(unit(3),*)vm(i),dimag(spinChi_iv(iorb,i)),dreal(spinChi_iv(iorb,i))
-        enddo
-        do i=1,3
-           close(unit(i))
-        enddo
-     endif
+     do i=1,Lreal
+        if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(spinChi_w(iorb,i)),dreal(spinChi_w(iorb,i))
+     enddo
+     do i=0,Lmats
+        write(unit(3),*)vm(i),dimag(spinChi_iv(iorb,i)),dreal(spinChi_iv(iorb,i))
+     enddo
+     do i=1,3
+        close(unit(i))
+     enddo
+  enddo
+  if(Norb>1)then
+     iorb=Norb+1
+     unit=free_units(3)
+     open(unit(1),file="spinChi_tot"//reg(txtfy(iorb))//"_tau"//reg(ed_file_suffix)//".ed")
+     open(unit(2),file="spinChi_tot"//reg(txtfy(iorb))//"_realw"//reg(ed_file_suffix)//".ed")
+     open(unit(3),file="spinChi_tot"//reg(txtfy(iorb))//"_iw"//reg(ed_file_suffix)//".ed")
+     do i=0,Ltau
+        write(unit(1),*)tau(i),spinChi_tau(iorb,i)
+     enddo
+     do i=1,Lreal
+        if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(spinChi_w(iorb,i)),dreal(spinChi_w(iorb,i))
+     enddo
+     do i=0,Lmats
+        write(unit(3),*)vm(i),dimag(spinChi_iv(iorb,i)),dreal(spinChi_iv(iorb,i))
+     enddo
+     do i=1,3
+        close(unit(i))
+     enddo
   endif
 end subroutine print_chi_spin
 
@@ -57,80 +55,74 @@ end subroutine print_chi_spin
 subroutine print_chi_dens
   integer                               :: i,j,iorb,jorb
   integer                               :: unit(3),unit_mix
-  if(ED_MPI_ID==0)then
-     do iorb=1,Norb
-        do jorb=iorb,Norb
-           unit=free_units(3)
-           open(unit(1),file="densChi_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_tau"//reg(ed_file_suffix)//".ed")
-           open(unit(2),file="densChi_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_realw"//reg(ed_file_suffix)//".ed")
-           open(unit(3),file="densChi_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_iw"//reg(ed_file_suffix)//".ed")
-           do i=0,Ltau
-              write(unit(1),*)tau(i),densChi_tau(iorb,jorb,i)
-           enddo
-           do i=1,Lreal
-              if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(densChi_w(iorb,jorb,i)),dreal(densChi_w(iorb,jorb,i))
-           enddo
-           do i=0,Lmats
-              write(unit(3),*)vm(i),dimag(densChi_iv(iorb,jorb,i)),dreal(densChi_iv(iorb,jorb,i))
-           enddo
-           do i=1,3
-              close(unit(i))
-           enddo
+  do iorb=1,Norb
+     do jorb=iorb,Norb
+        unit=free_units(3)
+        open(unit(1),file="densChi_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_tau"//reg(ed_file_suffix)//".ed")
+        open(unit(2),file="densChi_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_realw"//reg(ed_file_suffix)//".ed")
+        open(unit(3),file="densChi_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_iw"//reg(ed_file_suffix)//".ed")
+        do i=0,Ltau
+           write(unit(1),*)tau(i),densChi_tau(iorb,jorb,i)
+        enddo
+        do i=1,Lreal
+           if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(densChi_w(iorb,jorb,i)),dreal(densChi_w(iorb,jorb,i))
+        enddo
+        do i=0,Lmats
+           write(unit(3),*)vm(i),dimag(densChi_iv(iorb,jorb,i)),dreal(densChi_iv(iorb,jorb,i))
+        enddo
+        do i=1,3
+           close(unit(i))
         enddo
      enddo
-  endif
+  enddo
 end subroutine print_chi_dens
 
 
 subroutine print_chi_dens_mix
   integer                               :: i,j,iorb,jorb
   integer                               :: unit(3),unit_mix
-  if(ED_MPI_ID==0)then
-     do iorb=1,Norb
-        do jorb=1,Norb
-           unit=free_units(3)
-           open(unit(1),file="densChi_mix_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_tau"//reg(ed_file_suffix)//".ed")
-           open(unit(2),file="densChi_mix_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_realw"//reg(ed_file_suffix)//".ed")
-           open(unit(3),file="densChi_mix_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_iw"//reg(ed_file_suffix)//".ed")
-           do i=0,Ltau
-              write(unit(1),*)tau(i),densChi_mix_tau(iorb,jorb,i)
-           enddo
-           do i=1,Lreal
-              if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(densChi_mix_w(iorb,jorb,i)),dreal(densChi_mix_w(iorb,jorb,i))
-           enddo
-           do i=0,Lmats
-              write(unit(3),*)vm(i),dimag(densChi_mix_iv(iorb,jorb,i)),dreal(densChi_mix_iv(iorb,jorb,i))
-           enddo
-           do i=1,3
-              close(unit(i))
-           enddo
+  do iorb=1,Norb
+     do jorb=1,Norb
+        unit=free_units(3)
+        open(unit(1),file="densChi_mix_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_tau"//reg(ed_file_suffix)//".ed")
+        open(unit(2),file="densChi_mix_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_realw"//reg(ed_file_suffix)//".ed")
+        open(unit(3),file="densChi_mix_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))//"_iw"//reg(ed_file_suffix)//".ed")
+        do i=0,Ltau
+           write(unit(1),*)tau(i),densChi_mix_tau(iorb,jorb,i)
+        enddo
+        do i=1,Lreal
+           if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(densChi_mix_w(iorb,jorb,i)),dreal(densChi_mix_w(iorb,jorb,i))
+        enddo
+        do i=0,Lmats
+           write(unit(3),*)vm(i),dimag(densChi_mix_iv(iorb,jorb,i)),dreal(densChi_mix_iv(iorb,jorb,i))
+        enddo
+        do i=1,3
+           close(unit(i))
         enddo
      enddo
-  endif
+  enddo
 end subroutine print_chi_dens_mix
 
 
 subroutine print_chi_dens_tot
   integer                               :: i,j,iorb,jorb
   integer                               :: unit(3),unit_mix
-  if(ED_MPI_ID==0)then
-     unit=free_units(3)
-     open(unit(1),file="densChi_tot_tau"//reg(ed_file_suffix)//".ed")
-     open(unit(2),file="densChi_tot_realw"//reg(ed_file_suffix)//".ed")
-     open(unit(3),file="densChi_tot_iw"//reg(ed_file_suffix)//".ed")
-     do i=0,Ltau
-        write(unit(1),*)tau(i),densChi_tot_tau(i)
-     enddo
-     do i=1,Lreal
-        if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(densChi_tot_w(i)),dreal(densChi_tot_w(i))
-     enddo
-     do i=0,Lmats
-        write(unit(3),*)vm(i),dimag(densChi_tot_iv(i)),dreal(densChi_tot_iv(i))
-     enddo
-     do i=1,3
-        close(unit(i))
-     enddo
-  endif
+  unit=free_units(3)
+  open(unit(1),file="densChi_tot_tau"//reg(ed_file_suffix)//".ed")
+  open(unit(2),file="densChi_tot_realw"//reg(ed_file_suffix)//".ed")
+  open(unit(3),file="densChi_tot_iw"//reg(ed_file_suffix)//".ed")
+  do i=0,Ltau
+     write(unit(1),*)tau(i),densChi_tot_tau(i)
+  enddo
+  do i=1,Lreal
+     if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(densChi_tot_w(i)),dreal(densChi_tot_w(i))
+  enddo
+  do i=0,Lmats
+     write(unit(3),*)vm(i),dimag(densChi_tot_iv(i)),dreal(densChi_tot_iv(i))
+  enddo
+  do i=1,3
+     close(unit(i))
+  enddo
 end subroutine print_chi_dens_tot
 
 
@@ -148,24 +140,22 @@ end subroutine print_chi_dens_tot
 subroutine print_chi_pair
   integer                               :: i,iorb
   integer                               :: unit(3)
-  if(ED_MPI_ID==0)then
-     do iorb=1,Norb
-        unit=free_units(3)
-        open(unit(1),file="pairChi_orb"//reg(txtfy(iorb))//"_tau"//reg(ed_file_suffix)//".ed")
-        open(unit(2),file="pairChi_orb"//reg(txtfy(iorb))//"_realw"//reg(ed_file_suffix)//".ed")
-        open(unit(3),file="pairChi_orb"//reg(txtfy(iorb))//"_iw"//reg(ed_file_suffix)//".ed")
-        do i=0,Ltau
-           write(unit(1),*)tau(i),pairChi_tau(iorb,i)
-        enddo
-        do i=1,Lreal
-           if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(pairChi_w(iorb,i)),dreal(pairChi_w(iorb,i))
-        enddo
-        do i=0,Lmats
-           write(unit(3),*)vm(i),dimag(pairChi_iv(iorb,i)),dreal(pairChi_iv(iorb,i))
-        enddo
-        do i=1,3
-           close(unit(i))
-        enddo
+  do iorb=1,Norb
+     unit=free_units(3)
+     open(unit(1),file="pairChi_orb"//reg(txtfy(iorb))//"_tau"//reg(ed_file_suffix)//".ed")
+     open(unit(2),file="pairChi_orb"//reg(txtfy(iorb))//"_realw"//reg(ed_file_suffix)//".ed")
+     open(unit(3),file="pairChi_orb"//reg(txtfy(iorb))//"_iw"//reg(ed_file_suffix)//".ed")
+     do i=0,Ltau
+        write(unit(1),*)tau(i),pairChi_tau(iorb,i)
      enddo
-  endif
+     do i=1,Lreal
+        if(wr(i)>=0.d0)write(unit(2),*)wr(i),dimag(pairChi_w(iorb,i)),dreal(pairChi_w(iorb,i))
+     enddo
+     do i=0,Lmats
+        write(unit(3),*)vm(i),dimag(pairChi_iv(iorb,i)),dreal(pairChi_iv(iorb,i))
+     enddo
+     do i=1,3
+        close(unit(i))
+     enddo
+  enddo
 end subroutine print_chi_pair

--- a/ED_IO/print_impG.f90
+++ b/ED_IO/print_impG.f90
@@ -35,23 +35,21 @@ subroutine print_impG_normal
   if(l/=totNorb)stop "print_gf_normal error counting the orbitals"
   !!
   !Print the impurity functions:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        if(ed_verbose<2)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,6(F20.12))")wm(i),(dimag(impGmats(ispin,ispin,iorb,jorb,i)),dreal(impGmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(2),"(F20.12,6(F20.12))")wr(i),(dimag(impGreal(ispin,ispin,iorb,jorb,i)),dreal(impGreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-        endif
-        call close_units()
-     enddo
-  endif
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     if(ed_verbose<2)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,6(F20.12))")wm(i),(dimag(impGmats(ispin,ispin,iorb,jorb,i)),dreal(impGmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(2),"(F20.12,6(F20.12))")wr(i),(dimag(impGreal(ispin,ispin,iorb,jorb,i)),dreal(impGreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+     endif
+     call close_units()
+  enddo
   !
   if(allocated(wm))deallocate(wm)
   if(allocated(wr))deallocate(wr)
@@ -119,33 +117,31 @@ subroutine print_impG_superc
   if(l/=totNorb)stop "print_gf_superc error counting the orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        if(ed_verbose<2)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,6(F20.12))")wm(i),&
-                   (dimag(impGmats(ispin,ispin,iorb,jorb,i)),dreal(impGmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lmats
-              write(unit(2),"(F20.12,6(F20.12))")wm(i),&
-                   (dimag(impFmats(ispin,ispin,iorb,jorb,i)),dreal(impFmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(3),"(F20.12,6(F20.12))")wr(i),&
-                   (dimag(impGreal(ispin,ispin,iorb,jorb,i)),dreal(impGreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(4),"(F20.12,6(F20.12))")wr(i),&
-                   (dimag(impFreal(ispin,ispin,iorb,jorb,i)),dreal(impFreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-        endif
-        call close_units
-     enddo
-  endif
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     if(ed_verbose<2)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,6(F20.12))")wm(i),&
+                (dimag(impGmats(ispin,ispin,iorb,jorb,i)),dreal(impGmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lmats
+           write(unit(2),"(F20.12,6(F20.12))")wm(i),&
+                (dimag(impFmats(ispin,ispin,iorb,jorb,i)),dreal(impFmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(3),"(F20.12,6(F20.12))")wr(i),&
+                (dimag(impGreal(ispin,ispin,iorb,jorb,i)),dreal(impGreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(4),"(F20.12,6(F20.12))")wr(i),&
+                (dimag(impFreal(ispin,ispin,iorb,jorb,i)),dreal(impFreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+     endif
+     call close_units
+  enddo
   !
   !
   if(allocated(wm))deallocate(wm)
@@ -265,28 +261,26 @@ subroutine print_impG_nonsu2
   if(l/=totNso)stop "print_gf_nonsu2 error counting the spin-orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNso
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        ispin=getIspin(l)
-        jspin=getJspin(l)
-        !
-        suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
-        call open_units(reg(suffix))
-        !
-        if(ed_verbose<2)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,2(F20.12))")wm(i),dimag(impGmats(ispin,jspin,iorb,jorb,i)),dreal(impGmats(ispin,jspin,iorb,jorb,i))
-           enddo
-           do i=1,Lreal
-              write(unit(2),"(F20.12,2(F20.12))")wr(i),dimag(impGreal(ispin,jspin,iorb,jorb,i)),dreal(impGreal(ispin,jspin,iorb,jorb,i))
-           enddo
-        endif
-        !
-        call close_units()
-     enddo
-  endif
+  do l=1,totNso
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     ispin=getIspin(l)
+     jspin=getJspin(l)
+     !
+     suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+     call open_units(reg(suffix))
+     !
+     if(ed_verbose<2)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,2(F20.12))")wm(i),dimag(impGmats(ispin,jspin,iorb,jorb,i)),dreal(impGmats(ispin,jspin,iorb,jorb,i))
+        enddo
+        do i=1,Lreal
+           write(unit(2),"(F20.12,2(F20.12))")wr(i),dimag(impGreal(ispin,jspin,iorb,jorb,i)),dreal(impGreal(ispin,jspin,iorb,jorb,i))
+        enddo
+     endif
+     !
+     call close_units()
+  enddo
   !
   !
   if(allocated(wm))deallocate(wm)
@@ -325,54 +319,52 @@ end subroutine print_impG_nonsu2
 subroutine print_impG_normal_lattice(iprint)
   integer :: iprint
   integer :: ispin,jspin,iorb,jorb
-  if(ED_MPI_MASTER)then
-     if(allocated(wm))deallocate(wm)
-     if(allocated(wr))deallocate(wr)
-     allocate(wm(Lmats))
-     allocate(wr(Lreal))
-     wm = pi/beta*(2*arange(1,Lmats)-1)
-     wr = linspace(wini,wfin,Lreal)
-     select case(iprint)
-     case (0)
-        write(LOGfile,*)"Gimp not written on file."
-     case(1)                  !print only diagonal elements
-        write(LOGfile,*)"write spin-orbital diagonal elements:"
-        do ispin=1,Nspin
-           do iorb=1,Norb
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-              call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-              call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,iorb,:),wr)
+  if(allocated(wm))deallocate(wm)
+  if(allocated(wr))deallocate(wr)
+  allocate(wm(Lmats))
+  allocate(wr(Lreal))
+  wm = pi/beta*(2*arange(1,Lmats)-1)
+  wr = linspace(wini,wfin,Lreal)
+  select case(iprint)
+  case (0)
+     write(LOGfile,*)"Gimp not written on file."
+  case(1)                  !print only diagonal elements
+     write(LOGfile,*)"write spin-orbital diagonal elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+           call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+           call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,iorb,:),wr)
+        enddo
+     enddo
+  case(2)                  !print spin-diagonal, all orbitals 
+     write(LOGfile,*)"write spin diagonal and all orbitals elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           do jorb=1,Norb
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+              call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+              call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,jorb,:),wr)
            enddo
         enddo
-     case(2)                  !print spin-diagonal, all orbitals 
-        write(LOGfile,*)"write spin diagonal and all orbitals elements:"
-        do ispin=1,Nspin
+     enddo
+  case default                  !print all off-diagonals
+     write(LOGfile,*)"write all elements:"
+     do ispin=1,Nspin
+        do jspin=1,Nspin
            do iorb=1,Norb
               do jorb=1,Norb
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-                 call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-                 call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,jorb,:),wr)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
+                 call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
+                 call store_data("LGimp"//reg(suffix),Grealii(:,ispin,jspin,iorb,jorb,:),wr)
               enddo
            enddo
         enddo
-     case default                  !print all off-diagonals
-        write(LOGfile,*)"write all elements:"
-        do ispin=1,Nspin
-           do jspin=1,Nspin
-              do iorb=1,Norb
-                 do jorb=1,Norb
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
-                    call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
-                    call store_data("LGimp"//reg(suffix),Grealii(:,ispin,jspin,iorb,jorb,:),wr)
-                 enddo
-              enddo
-           enddo
-        enddo
-     end select
-  endif
+     enddo
+  end select
 end subroutine print_impG_normal_lattice
 
 
@@ -380,60 +372,58 @@ end subroutine print_impG_normal_lattice
 subroutine print_impG_superc_lattice(iprint)
   integer :: iprint
   integer :: ispin,jspin,iorb,jorb
-  if(ED_MPI_MASTER)then
-     if(allocated(wm))deallocate(wm)
-     if(allocated(wr))deallocate(wr)
-     allocate(wm(Lmats))
-     allocate(wr(Lreal))
-     wm = pi/beta*(2*arange(1,Lmats)-1)
-     wr = linspace(wini,wfin,Lreal)
-     select case(iprint)
-     case (0)
-        write(LOGfile,*)"Gimp not written on file."
-     case(1)                  !print only diagonal elements
-        write(LOGfile,*)"write spin-orbital diagonal elements:"
-        do ispin=1,Nspin
-           do iorb=1,Norb
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-              call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              call store_data("LFimp"//reg(suffix),Fmatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-              call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,iorb,:),wr)
-              call store_data("LFimp"//reg(suffix),Frealii(:,ispin,ispin,iorb,iorb,:),wr)
+  if(allocated(wm))deallocate(wm)
+  if(allocated(wr))deallocate(wr)
+  allocate(wm(Lmats))
+  allocate(wr(Lreal))
+  wm = pi/beta*(2*arange(1,Lmats)-1)
+  wr = linspace(wini,wfin,Lreal)
+  select case(iprint)
+  case (0)
+     write(LOGfile,*)"Gimp not written on file."
+  case(1)                  !print only diagonal elements
+     write(LOGfile,*)"write spin-orbital diagonal elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+           call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           call store_data("LFimp"//reg(suffix),Fmatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+           call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,iorb,:),wr)
+           call store_data("LFimp"//reg(suffix),Frealii(:,ispin,ispin,iorb,iorb,:),wr)
+        enddo
+     enddo
+  case(2)                  !print spin-diagonal, all orbitals 
+     write(LOGfile,*)"write spin diagonal and all orbitals elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           do jorb=1,Norb
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+              call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              call store_data("LFimp"//reg(suffix),Fmatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+              call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,jorb,:),wr)
+              call store_data("LFimp"//reg(suffix),Frealii(:,ispin,ispin,iorb,jorb,:),wr)
            enddo
         enddo
-     case(2)                  !print spin-diagonal, all orbitals 
-        write(LOGfile,*)"write spin diagonal and all orbitals elements:"
-        do ispin=1,Nspin
+     enddo
+  case default                  !print all off-diagonals
+     write(LOGfile,*)"write all elements:"
+     do ispin=1,Nspin
+        do jspin=1,Nspin
            do iorb=1,Norb
               do jorb=1,Norb
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-                 call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 call store_data("LFimp"//reg(suffix),Fmatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-                 call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,jorb,:),wr)
-                 call store_data("LFimp"//reg(suffix),Frealii(:,ispin,ispin,iorb,jorb,:),wr)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
+                 call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 call store_data("LFimp"//reg(suffix),Fmatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
+                 call store_data("LGimp"//reg(suffix),Grealii(:,ispin,jspin,iorb,jorb,:),wr)
+                 call store_data("LFimp"//reg(suffix),Frealii(:,ispin,jspin,iorb,jorb,:),wr)
               enddo
            enddo
         enddo
-     case default                  !print all off-diagonals
-        write(LOGfile,*)"write all elements:"
-        do ispin=1,Nspin
-           do jspin=1,Nspin
-              do iorb=1,Norb
-                 do jorb=1,Norb
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
-                    call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    call store_data("LFimp"//reg(suffix),Fmatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
-                    call store_data("LGimp"//reg(suffix),Grealii(:,ispin,jspin,iorb,jorb,:),wr)
-                    call store_data("LFimp"//reg(suffix),Frealii(:,ispin,jspin,iorb,jorb,:),wr)
-                 enddo
-              enddo
-           enddo
-        enddo
-     end select
-  endif
+     enddo
+  end select
 end subroutine print_impG_superc_lattice
 
 
@@ -441,52 +431,50 @@ end subroutine print_impG_superc_lattice
 subroutine print_impG_nonsu2_lattice(iprint)
   integer :: iprint
   integer :: ispin,jspin,iorb,jorb
-  if(ED_MPI_MASTER)then
-     if(allocated(wm))deallocate(wm)
-     if(allocated(wr))deallocate(wr)
-     allocate(wm(Lmats))
-     allocate(wr(Lreal))
-     wm = pi/beta*(2*arange(1,Lmats)-1)
-     wr = linspace(wini,wfin,Lreal)
-     select case(iprint)
-     case (0)
-        write(LOGfile,*)"Gimp not written on file."
-     case(1)                  !print only diagonal elements
-        write(LOGfile,*)"write spin-orbital diagonal elements:"
-        do ispin=1,Nspin
-           do iorb=1,Norb
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-              call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-              call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,iorb,:),wr)
+  if(allocated(wm))deallocate(wm)
+  if(allocated(wr))deallocate(wr)
+  allocate(wm(Lmats))
+  allocate(wr(Lreal))
+  wm = pi/beta*(2*arange(1,Lmats)-1)
+  wr = linspace(wini,wfin,Lreal)
+  select case(iprint)
+  case (0)
+     write(LOGfile,*)"Gimp not written on file."
+  case(1)                  !print only diagonal elements
+     write(LOGfile,*)"write spin-orbital diagonal elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+           call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+           call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,iorb,:),wr)
+        enddo
+     enddo
+  case(2)                  !print spin-diagonal, all orbitals 
+     write(LOGfile,*)"write spin diagonal and all orbitals elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           do jorb=1,Norb
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+              call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+              call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,jorb,:),wr)
            enddo
         enddo
-     case(2)                  !print spin-diagonal, all orbitals 
-        write(LOGfile,*)"write spin diagonal and all orbitals elements:"
-        do ispin=1,Nspin
+     enddo
+  case default                  !print all off-diagonals
+     write(LOGfile,*)"write all elements:"
+     do ispin=1,Nspin
+        do jspin=1,Nspin
            do iorb=1,Norb
               do jorb=1,Norb
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-                 call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-                 call store_data("LGimp"//reg(suffix),Grealii(:,ispin,ispin,iorb,jorb,:),wr)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
+                 call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
+                 call store_data("LGimp"//reg(suffix),Grealii(:,ispin,jspin,iorb,jorb,:),wr)
               enddo
            enddo
         enddo
-     case default                  !print all off-diagonals
-        write(LOGfile,*)"write all elements:"
-        do ispin=1,Nspin
-           do jspin=1,Nspin
-              do iorb=1,Norb
-                 do jorb=1,Norb
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
-                    call store_data("LGimp"//reg(suffix),Gmatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
-                    call store_data("LGimp"//reg(suffix),Grealii(:,ispin,jspin,iorb,jorb,:),wr)
-                 enddo
-              enddo
-           enddo
-        enddo
-     end select
-  endif
+     enddo
+  end select
 end subroutine print_impG_nonsu2_lattice

--- a/ED_IO/print_impG0.f90
+++ b/ED_IO/print_impG0.f90
@@ -35,23 +35,21 @@ subroutine print_impG0_normal
   if(l/=totNorb)stop "print_gf_normal error counting the orbitals"
   !!
   !Print the impurity functions:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        if(ed_verbose<1)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,6(F20.12))")wm(i),(dimag(impG0mats(ispin,ispin,iorb,jorb,i)),dreal(impG0mats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(2),"(F20.12,6(F20.12))")wr(i),(dimag(impG0real(ispin,ispin,iorb,jorb,i)),dreal(impG0real(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-        endif
-        call close_units()
-     enddo
-  endif
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     if(ed_verbose<1)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,6(F20.12))")wm(i),(dimag(impG0mats(ispin,ispin,iorb,jorb,i)),dreal(impG0mats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(2),"(F20.12,6(F20.12))")wr(i),(dimag(impG0real(ispin,ispin,iorb,jorb,i)),dreal(impG0real(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+     endif
+     call close_units()
+  enddo
   !
   if(allocated(wm))deallocate(wm)
   if(allocated(wr))deallocate(wr)
@@ -118,33 +116,31 @@ subroutine print_impG0_superc
   !!
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        if(ed_verbose<1)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,6(F20.12))")wm(i),&
-                   (dimag(impG0mats(ispin,ispin,iorb,jorb,i)),dreal(impG0mats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lmats
-              write(unit(2),"(F20.12,6(F20.12))")wm(i),&
-                   (dimag(impF0mats(ispin,ispin,iorb,jorb,i)),dreal(impF0mats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(3),"(F20.12,6(F20.12))")wr(i),&
-                   (dimag(impG0real(ispin,ispin,iorb,jorb,i)),dreal(impG0real(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(4),"(F20.12,6(F20.12))")wr(i),&
-                   (dimag(impF0real(ispin,ispin,iorb,jorb,i)),dreal(impF0real(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-        endif
-        call close_units
-     enddo
-  endif
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     if(ed_verbose<1)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,6(F20.12))")wm(i),&
+                (dimag(impG0mats(ispin,ispin,iorb,jorb,i)),dreal(impG0mats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lmats
+           write(unit(2),"(F20.12,6(F20.12))")wm(i),&
+                (dimag(impF0mats(ispin,ispin,iorb,jorb,i)),dreal(impF0mats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(3),"(F20.12,6(F20.12))")wr(i),&
+                (dimag(impG0real(ispin,ispin,iorb,jorb,i)),dreal(impG0real(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(4),"(F20.12,6(F20.12))")wr(i),&
+                (dimag(impF0real(ispin,ispin,iorb,jorb,i)),dreal(impF0real(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+     endif
+     call close_units
+  enddo
   !
   !
   if(allocated(wm))deallocate(wm)
@@ -270,27 +266,25 @@ subroutine print_impG0_nonsu2
   if(l/=totNso)stop "print_gf_nonsu2 error counting the spin-orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNso
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        ispin=getIspin(l)
-        jspin=getJspin(l)
-        !
-        suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
-        call open_units(reg(suffix))
-        !
-        if(ed_verbose<1)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,2(F20.12))")wm(i),dimag(impG0mats(ispin,jspin,iorb,jorb,i)),dreal(impG0mats(ispin,jspin,iorb,jorb,i))
-           enddo
-           do i=1,Lreal
-              write(unit(2),"(F20.12,2(F20.12))")wr(i),dimag(impG0real(ispin,jspin,iorb,jorb,i)),dreal(impG0real(ispin,jspin,iorb,jorb,i))
-           enddo
-        endif
-        call close_units()
-     enddo
-  endif
+  do l=1,totNso
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     ispin=getIspin(l)
+     jspin=getJspin(l)
+     !
+     suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+     call open_units(reg(suffix))
+     !
+     if(ed_verbose<1)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,2(F20.12))")wm(i),dimag(impG0mats(ispin,jspin,iorb,jorb,i)),dreal(impG0mats(ispin,jspin,iorb,jorb,i))
+        enddo
+        do i=1,Lreal
+           write(unit(2),"(F20.12,2(F20.12))")wr(i),dimag(impG0real(ispin,jspin,iorb,jorb,i)),dreal(impG0real(ispin,jspin,iorb,jorb,i))
+        enddo
+     endif
+     call close_units()
+  enddo
   !
   if(allocated(wm))deallocate(wm)
   if(allocated(wr))deallocate(wr)

--- a/ED_IO/print_impSigma.f90
+++ b/ED_IO/print_impSigma.f90
@@ -35,23 +35,21 @@ subroutine print_impSigma_normal
   if(l/=totNorb)stop "print_gf_normal error counting the orbitals"
   !!
   !Print the impurity functions:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        if(ed_verbose<4)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,6(F20.12))")wm(i),(dimag(impSmats(ispin,ispin,iorb,jorb,i)),dreal(impSmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(2),"(F20.12,6(F20.12))")wr(i),(dimag(impSreal(ispin,ispin,iorb,jorb,i)),dreal(impSreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-        endif
-        call close_units()
-     enddo
-  endif
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     if(ed_verbose<4)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,6(F20.12))")wm(i),(dimag(impSmats(ispin,ispin,iorb,jorb,i)),dreal(impSmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(2),"(F20.12,6(F20.12))")wr(i),(dimag(impSreal(ispin,ispin,iorb,jorb,i)),dreal(impSreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+     endif
+     call close_units()
+  enddo
   !
   if(allocated(wm))deallocate(wm)
   if(allocated(wr))deallocate(wr)
@@ -117,33 +115,31 @@ subroutine print_impSigma_superc
   if(l/=totNorb)stop "print_gf_superc error counting the orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNorb
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
-        call open_units(reg(suffix))
-        if(ed_verbose<4)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,6(F20.12))")wm(i),&
-                   (dimag(impSmats(ispin,ispin,iorb,jorb,i)),dreal(impSmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lmats
-              write(unit(2),"(F20.12,6(F20.12))")wm(i),&
-                   (dimag(impSAmats(ispin,ispin,iorb,jorb,i)),dreal(impSAmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(3),"(F20.12,6(F20.12))")wr(i),&
-                   (dimag(impSreal(ispin,ispin,iorb,jorb,i)),dreal(impSreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-           do i=1,Lreal
-              write(unit(4),"(F20.12,6(F20.12))")wr(i),&
-                   (dimag(impSAreal(ispin,ispin,iorb,jorb,i)),dreal(impSAreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
-           enddo
-        endif
-        call close_units
-     enddo
-  endif
+  do l=1,totNorb
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     suffix="_l"//reg(txtfy(iorb))//"_m"//reg(txtfy(jorb))
+     call open_units(reg(suffix))
+     if(ed_verbose<4)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,6(F20.12))")wm(i),&
+                (dimag(impSmats(ispin,ispin,iorb,jorb,i)),dreal(impSmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lmats
+           write(unit(2),"(F20.12,6(F20.12))")wm(i),&
+                (dimag(impSAmats(ispin,ispin,iorb,jorb,i)),dreal(impSAmats(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(3),"(F20.12,6(F20.12))")wr(i),&
+                (dimag(impSreal(ispin,ispin,iorb,jorb,i)),dreal(impSreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+        do i=1,Lreal
+           write(unit(4),"(F20.12,6(F20.12))")wr(i),&
+                (dimag(impSAreal(ispin,ispin,iorb,jorb,i)),dreal(impSAreal(ispin,ispin,iorb,jorb,i)),ispin=1,Nspin)
+        enddo
+     endif
+     call close_units
+  enddo
   !
   !
   if(allocated(wm))deallocate(wm)
@@ -262,28 +258,26 @@ subroutine print_impSigma_nonsu2
   if(l/=totNso)stop "print_gf_nonsu2 error counting the spin-orbitals"
   !!
   !!PRINT OUT GF:
-  if(ED_MPI_ID==0)then
-     do l=1,totNso
-        iorb=getIorb(l)
-        jorb=getJorb(l)
-        ispin=getIspin(l)
-        jspin=getJspin(l)
-        !
-        suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
-        call open_units(reg(suffix))
-        !
-        if(ed_verbose<4)then
-           do i=1,Lmats
-              write(unit(1),"(F20.12,2(F20.12))")wm(i),dimag(impSmats(ispin,jspin,iorb,jorb,i)),dreal(impSmats(ispin,jspin,iorb,jorb,i))
-           enddo
-           do i=1,Lreal
-              write(unit(1),"(F20.12,2(F20.12))")wr(i),dimag(impSreal(ispin,jspin,iorb,jorb,i)),dreal(impSreal(ispin,jspin,iorb,jorb,i))
-           enddo
-        endif
-        !
-        call close_units()
-     enddo
-  endif
+  do l=1,totNso
+     iorb=getIorb(l)
+     jorb=getJorb(l)
+     ispin=getIspin(l)
+     jspin=getJspin(l)
+     !
+     suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))
+     call open_units(reg(suffix))
+     !
+     if(ed_verbose<4)then
+        do i=1,Lmats
+           write(unit(1),"(F20.12,2(F20.12))")wm(i),dimag(impSmats(ispin,jspin,iorb,jorb,i)),dreal(impSmats(ispin,jspin,iorb,jorb,i))
+        enddo
+        do i=1,Lreal
+           write(unit(1),"(F20.12,2(F20.12))")wr(i),dimag(impSreal(ispin,jspin,iorb,jorb,i)),dreal(impSreal(ispin,jspin,iorb,jorb,i))
+        enddo
+     endif
+     !
+     call close_units()
+  enddo
   !
   !
   if(allocated(wm))deallocate(wm)
@@ -318,54 +312,52 @@ end subroutine print_impSigma_nonsu2
 subroutine print_impSigma_normal_lattice(iprint)
   integer :: iprint
   integer :: ispin,jspin,iorb,jorb
-  if(ED_MPI_MASTER)then
-     if(allocated(wm))deallocate(wm)
-     if(allocated(wr))deallocate(wr)
-     allocate(wm(Lmats))
-     allocate(wr(Lreal))
-     wm = pi/beta*(2*arange(1,Lmats)-1)
-     wr = linspace(wini,wfin,Lreal)
-     select case(iprint)
-     case (0)
-        write(LOGfile,*)"Sigma not written on file."
-     case(1)                  !print only diagonal elements
-        write(LOGfile,*)"write spin-orbital diagonal elements:"
-        do ispin=1,Nspin
-           do iorb=1,Norb
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-              call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-              call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,iorb,:),wr)
+  if(allocated(wm))deallocate(wm)
+  if(allocated(wr))deallocate(wr)
+  allocate(wm(Lmats))
+  allocate(wr(Lreal))
+  wm = pi/beta*(2*arange(1,Lmats)-1)
+  wr = linspace(wini,wfin,Lreal)
+  select case(iprint)
+  case (0)
+     write(LOGfile,*)"Sigma not written on file."
+  case(1)                  !print only diagonal elements
+     write(LOGfile,*)"write spin-orbital diagonal elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+           call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+           call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,iorb,:),wr)
+        enddo
+     enddo
+  case(2)                  !print spin-diagonal, all orbitals 
+     write(LOGfile,*)"write spin diagonal and all orbitals elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           do jorb=1,Norb
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+              call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+              call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,jorb,:),wr)
            enddo
         enddo
-     case(2)                  !print spin-diagonal, all orbitals 
-        write(LOGfile,*)"write spin diagonal and all orbitals elements:"
-        do ispin=1,Nspin
+     enddo
+  case default                  !print all off-diagonals
+     write(LOGfile,*)"write all elements:"
+     do ispin=1,Nspin
+        do jspin=1,Nspin
            do iorb=1,Norb
               do jorb=1,Norb
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-                 call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-                 call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,jorb,:),wr)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
+                 call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
+                 call store_data("LSigma"//reg(suffix),Srealii(:,ispin,jspin,iorb,jorb,:),wr)
               enddo
            enddo
         enddo
-     case default                  !print all off-diagonals
-        write(LOGfile,*)"write all elements:"
-        do ispin=1,Nspin
-           do jspin=1,Nspin
-              do iorb=1,Norb
-                 do jorb=1,Norb
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
-                    call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
-                    call store_data("LSigma"//reg(suffix),Srealii(:,ispin,jspin,iorb,jorb,:),wr)
-                 enddo
-              enddo
-           enddo
-        enddo
-     end select
-  endif
+     enddo
+  end select
 end subroutine print_impSigma_normal_lattice
 
 
@@ -374,59 +366,57 @@ end subroutine print_impSigma_normal_lattice
 subroutine print_impSigma_superc_lattice(iprint)
   integer :: iprint
   integer :: ispin,jspin,iorb,jorb
-  if(ED_MPI_MASTER)then
-     if(allocated(wm))deallocate(wm)
-     if(allocated(wr))deallocate(wr)
-     allocate(wm(Lmats))
-     allocate(wr(Lreal))
-     wm = pi/beta*(2*arange(1,Lmats)-1)
-     wr = linspace(wini,wfin,Lreal)
-     select case(iprint)
-     case (0)
-        write(LOGfile,*)"Sigma not written on file."
-     case(1)                  !print only diagonal elements
-        write(LOGfile,*)"write spin-orbital diagonal elements:"
-        do ispin=1,Nspin
-           do iorb=1,Norb
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-              call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              call store_data("LSelf"//reg(suffix),SAmatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-              call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,iorb,:),wr)
-              call store_data("LSelf"//reg(suffix),SArealii(:,ispin,ispin,iorb,iorb,:),wr)
+  if(allocated(wm))deallocate(wm)
+  if(allocated(wr))deallocate(wr)
+  allocate(wm(Lmats))
+  allocate(wr(Lreal))
+  wm = pi/beta*(2*arange(1,Lmats)-1)
+  wr = linspace(wini,wfin,Lreal)
+  select case(iprint)
+  case (0)
+     write(LOGfile,*)"Sigma not written on file."
+  case(1)                  !print only diagonal elements
+     write(LOGfile,*)"write spin-orbital diagonal elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+           call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           call store_data("LSelf"//reg(suffix),SAmatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+           call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,iorb,:),wr)
+           call store_data("LSelf"//reg(suffix),SArealii(:,ispin,ispin,iorb,iorb,:),wr)
+        enddo
+     enddo
+  case(2)                  !print spin-diagonal, all orbitals 
+     write(LOGfile,*)"write spin diagonal and all orbitals elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           do jorb=1,Norb
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+              call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              call store_data("LSelf"//reg(suffix),SAmatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,jorb,:),wr)
+              call store_data("LSelf"//reg(suffix),SArealii(:,ispin,ispin,iorb,jorb,:),wr)
            enddo
         enddo
-     case(2)                  !print spin-diagonal, all orbitals 
-        write(LOGfile,*)"write spin diagonal and all orbitals elements:"
-        do ispin=1,Nspin
+     enddo
+  case default                  !print all off-diagonals
+     write(LOGfile,*)"write all elements:"
+     do ispin=1,Nspin
+        do jspin=1,Nspin
            do iorb=1,Norb
               do jorb=1,Norb
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-                 call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 call store_data("LSelf"//reg(suffix),SAmatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,jorb,:),wr)
-                 call store_data("LSelf"//reg(suffix),SArealii(:,ispin,ispin,iorb,jorb,:),wr)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
+                 call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 call store_data("LSelf"//reg(suffix),SAmatsii(:,ispin,jspin,iorb,jorb,:),wm)                                          
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
+                 call store_data("LSigma"//reg(suffix),Srealii(:,ispin,jspin,iorb,jorb,:),wr)
+                 call store_data("LSelf"//reg(suffix),SArealii(:,ispin,jspin,iorb,jorb,:),wr)
               enddo
            enddo
         enddo
-     case default                  !print all off-diagonals
-        write(LOGfile,*)"write all elements:"
-        do ispin=1,Nspin
-           do jspin=1,Nspin
-              do iorb=1,Norb
-                 do jorb=1,Norb
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
-                    call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    call store_data("LSelf"//reg(suffix),SAmatsii(:,ispin,jspin,iorb,jorb,:),wm)                                          
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
-                    call store_data("LSigma"//reg(suffix),Srealii(:,ispin,jspin,iorb,jorb,:),wr)
-                    call store_data("LSelf"//reg(suffix),SArealii(:,ispin,jspin,iorb,jorb,:),wr)
-                 enddo
-              enddo
-           enddo
-        enddo
-     end select
-  endif
+     enddo
+  end select
 end subroutine print_impSigma_superc_lattice
 
 
@@ -435,52 +425,50 @@ end subroutine print_impSigma_superc_lattice
 subroutine print_impSigma_nonsu2_lattice(iprint)
   integer :: iprint
   integer :: ispin,jspin,iorb,jorb
-  if(ED_MPI_MASTER)then
-     if(allocated(wm))deallocate(wm)
-     if(allocated(wr))deallocate(wr)
-     allocate(wm(Lmats))
-     allocate(wr(Lreal))
-     wm = pi/beta*(2*arange(1,Lmats)-1)
-     wr = linspace(wini,wfin,Lreal)
-     select case(iprint)
-     case (0)
-        write(LOGfile,*)"Sigma not written on file."
-     case(1)                  !print only diagonal elements
-        write(LOGfile,*)"write spin-orbital diagonal elements:"
-        do ispin=1,Nspin
-           do iorb=1,Norb
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-              call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,iorb,:),wm)
-              suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-              call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,iorb,:),wr)
+  if(allocated(wm))deallocate(wm)
+  if(allocated(wr))deallocate(wr)
+  allocate(wm(Lmats))
+  allocate(wr(Lreal))
+  wm = pi/beta*(2*arange(1,Lmats)-1)
+  wr = linspace(wini,wfin,Lreal)
+  select case(iprint)
+  case (0)
+     write(LOGfile,*)"Sigma not written on file."
+  case(1)                  !print only diagonal elements
+     write(LOGfile,*)"write spin-orbital diagonal elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+           call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,iorb,:),wm)
+           suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+           call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,iorb,:),wr)
+        enddo
+     enddo
+  case(2)                  !print spin-diagonal, all orbitals 
+     write(LOGfile,*)"write spin diagonal and all orbitals elements:"
+     do ispin=1,Nspin
+        do iorb=1,Norb
+           do jorb=1,Norb
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+              call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,jorb,:),wm)
+              suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+              call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,jorb,:),wr)
            enddo
         enddo
-     case(2)                  !print spin-diagonal, all orbitals 
-        write(LOGfile,*)"write spin diagonal and all orbitals elements:"
-        do ispin=1,Nspin
+     enddo
+  case default                  !print all off-diagonals
+     write(LOGfile,*)"write all elements:"
+     do ispin=1,Nspin
+        do jspin=1,Nspin
            do iorb=1,Norb
               do jorb=1,Norb
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-                 call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,ispin,iorb,jorb,:),wm)
-                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-                 call store_data("LSigma"//reg(suffix),Srealii(:,ispin,ispin,iorb,jorb,:),wr)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
+                 call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,jspin,iorb,jorb,:),wm)
+                 suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
+                 call store_data("LSigma"//reg(suffix),Srealii(:,ispin,jspin,iorb,jorb,:),wr)
               enddo
            enddo
         enddo
-     case default                  !print all off-diagonals
-        write(LOGfile,*)"write all elements:"
-        do ispin=1,Nspin
-           do jspin=1,Nspin
-              do iorb=1,Norb
-                 do jorb=1,Norb
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_iw.ed"
-                    call store_data("LSigma"//reg(suffix),Smatsii(:,ispin,jspin,iorb,jorb,:),wm)
-                    suffix="_l"//reg(txtfy(iorb))//reg(txtfy(jorb))//"_s"//reg(txtfy(ispin))//reg(txtfy(jspin))//"_realw.ed"
-                    call store_data("LSigma"//reg(suffix),Srealii(:,ispin,jspin,iorb,jorb,:),wr)
-                 enddo
-              enddo
-           enddo
-        enddo
-     end select
-  endif
+     enddo
+  end select
 end subroutine print_impSigma_nonsu2_lattice

--- a/ED_MAIN.f90
+++ b/ED_MAIN.f90
@@ -10,12 +10,15 @@ module ED_MAIN
   USE ED_HAMILTONIAN
   USE ED_GREENS_FUNCTIONS
   USE ED_OBSERVABLES
-  USE ED_ENERGY
   USE ED_DIAG
   USE SF_LINALG
   USE SF_ARRAYS, only: linspace,arange
   USE SF_IOTOOLS, only: str,reg,store_data,txtfy,free_unit
   USE SF_TIMER,only: start_timer,stop_timer
+#ifdef _MPI
+  USE MPI
+  USE SF_MPI
+#endif
   implicit none
   private
 
@@ -23,27 +26,44 @@ module ED_MAIN
   interface ed_init_solver
      module procedure :: ed_init_solver_single
      module procedure :: ed_init_solver_lattice
+#ifdef _MPI
+     module procedure :: ed_init_solver_single_mpi
+     module procedure :: ed_init_solver_lattice_mpi
+#endif
   end interface ed_init_solver
+  public :: ed_init_solver
+
 
 
   interface ed_solve
      module procedure :: ed_solve_single
      module procedure :: ed_solve_lattice
+#ifdef _MPI
+     module procedure :: ed_solve_single_mpi
+     module procedure :: ed_solve_lattice_mpi
+#endif
   end interface ed_solve
+  public :: ed_solve
+
+
 
   interface ed_rebuild_sigma
      module procedure :: ed_rebuild_sigma_single
      module procedure :: ed_rebuild_sigma_lattice
+#ifdef _MPI
+     module procedure :: ed_rebuild_sigma_single_mpi
+     module procedure :: ed_rebuild_sigma_lattice_mpi
+#endif
   end interface ed_rebuild_sigma
-
-
-  public :: ed_init_solver
-  public :: ed_solve
   public :: ed_rebuild_sigma
-  !
+
+
+
 
   real(8),dimension(:),allocatable                   :: wr,wm
   character(len=64)                                  :: suffix
+
+
 
 contains
 
@@ -52,51 +72,38 @@ contains
   !+-----------------------------------------------------------------------------+!
   ! PURPOSE: allocate and initialize one or multiple baths -+!
   !+-----------------------------------------------------------------------------+!
-  subroutine ed_init_solver_single(bath,Hloc,hwband,Hunit,MpiComm)
+  !                              SINGLE SITE                                      !
+  !+-----------------------------------------------------------------------------+!
+  subroutine ed_init_solver_single(bath,Hloc)
+    real(8),dimension(:),intent(inout) :: bath
+    complex(8),optional,intent(in)     :: Hloc(Nspin,Nspin,Norb,Norb)
+    logical                            :: check 
+    logical,save                       :: isetup=.true.
+    integer                            :: i
+    logical                            :: MPI_MASTER=.true.
+    integer                            :: MPI_ERR
     !
-    integer,optional                     :: MpiComm
+    if(ed_verbose<2.AND.MPI_MASTER)write(LOGfile,"(A)")"INIT SOLVER FOR "//trim(ed_file_suffix)
     !
-    real(8),dimension(:),intent(inout)   :: bath
-    complex(8),optional,intent(in)       :: Hloc(Nspin,Nspin,Norb,Norb)
-    real(8),optional,intent(in)          :: hwband
-    character(len=*),optional,intent(in) :: Hunit
-    real(8)                              :: hwband_
-    character(len=64)                    :: Hunit_
-    logical                              :: check 
-    logical,save                         :: isetup=.true.
-    integer                              :: i
-#ifdef _MPI
-    if(present(MpiComm))then
-       ED_MPI_COMM = MpiComm
-    else
-       ED_MPI_COMM = MPI_COMM_WORLD
-    end if
-    ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
-    ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
-    ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
-#endif
-    if(ed_verbose<2.AND.ED_MPI_ID==0)write(LOGfile,"(A)")"INIT SOLVER FOR "//trim(ed_file_suffix)
-    hwband_=2.d0;if(present(hwband))hwband_=hwband
-    Hunit_='inputHLOC.in';if(present(Hunit))Hunit_=Hunit
     if(present(Hloc))then
        check = check_bath_dimension(bath,Hloc)
     else
        check = check_bath_dimension(bath)
     endif
-    if(.not.check)stop "init_ed_solver: wrong bath dimensions"
+    if(.not.check)stop "init_ed_solver_single error: wrong bath dimensions"
+    !
     bath = 0d0
-    if(isetup)call init_ed_structure(Hunit_)
+    !
+    !Init ED Structure & memory
+    if(isetup)call init_ed_structure()
+    !
+    !Init bath:
     if(present(Hloc))call set_hloc(Hloc)
+    !
     call allocate_dmft_bath(dmft_bath)
     if(bath_type=="replica")call init_dmft_bath_mask(dmft_bath)
-    call init_dmft_bath(dmft_bath,hwband_)
+    call init_dmft_bath(dmft_bath)
     call get_dmft_bath(dmft_bath,bath)
-    !
-    !DEBUG>
-    !call write_dmft_bath(dmft_bath,LOGfile)
-    ! if(ED_MPI_ID==0)write(LOGfile,'(20(F12.6,1X))') bath
-    !stop
-    !>DEBUG
     !
     if(isetup)then
        select case(ed_mode)
@@ -110,64 +117,144 @@ contains
     endif
     call deallocate_dmft_bath(dmft_bath)
     isetup=.false.
+    !
   end subroutine ed_init_solver_single
 
-  subroutine ed_init_solver_lattice(bath,Hloc,hwband,Hunit,MpiComm)
-    !
-    integer,optional                     :: MpiComm
-    !
-    real(8),dimension(:,:)               :: bath ![Nlat][:]
-    real(8),optional,intent(in)          :: hwband
-    complex(8),optional,intent(in)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
-    character(len=*),optional,intent(in) :: Hunit
-    real(8)                              :: hwband_
-    character(len=64)                    :: Hunit_
-    integer                              :: ilat,Nineq,Nsect
-    logical                              :: check_dim
-    character(len=5)                     :: tmp_suffix
 #ifdef _MPI
-    if(present(MpiComm))then
-       ED_MPI_COMM = MpiComm
-    else
-       ED_MPI_COMM = MPI_COMM_WORLD
-    end if
-    ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
-    ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
-    ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
-#endif
+  subroutine ed_init_solver_single_mpi(MpiComm,bath,Hloc)
+    integer                            :: MpiComm
+    real(8),dimension(:),intent(inout) :: bath
+    complex(8),optional,intent(in)     :: Hloc(Nspin,Nspin,Norb,Norb)
+    logical                            :: check 
+    logical,save                       :: isetup=.true.
+    integer                            :: i
+    logical                            :: MPI_MASTER=.true.
+    integer                            :: MPI_ERR
     !
-    hwband_=2.d0;if(present(hwband))hwband_=hwband
-    Hunit_='inputHLOC.in';if(present(Hunit))Hunit_=Hunit
+    MPI_MASTER = get_Master_MPI(MpiComm)
+    !
+    if(ed_verbose<2.AND.MPI_MASTER)write(LOGfile,"(A)")"INIT SOLVER FOR "//trim(ed_file_suffix)
+    !
+    if(present(Hloc))then
+       check = check_bath_dimension(bath,Hloc)
+    else
+       check = check_bath_dimension(bath)
+    endif
+    if(.not.check)stop "init_ed_solver_single error: wrong bath dimensions"
+    !
+    bath = 0d0
+    !
+    !Init ED Structure & memory
+    if(isetup)call init_ed_structure(MpiComm)
+    !
+    !Init bath:
+    if(present(Hloc))call set_hloc(Hloc)
+    !
+    call allocate_dmft_bath(dmft_bath)
+    if(bath_type=="replica")call init_dmft_bath_mask(dmft_bath)
+    call init_dmft_bath(dmft_bath)
+    call get_dmft_bath(dmft_bath,bath)
+    !
+    if(isetup)then
+       select case(ed_mode)
+       case default
+          call setup_pointers_normal
+       case ("superc")
+          call setup_pointers_superc
+       case ("nonsu2")
+          call setup_pointers_nonsu2
+       end select
+    endif
+    call deallocate_dmft_bath(dmft_bath)
+    isetup=.false.
+    !
+    call MPI_Barrier(MpiComm,MPI_ERR)
+    !
+  end subroutine ed_init_solver_single_mpi
+#endif
+
+
+
+
+  !+-----------------------------------------------------------------------------+!
+  !                           INEQUVALENT SITES                                   !
+  !+-----------------------------------------------------------------------------+!
+  subroutine ed_init_solver_lattice(bath,Hloc)
+    real(8),dimension(:,:)         :: bath ![Nlat][:]
+    complex(8),optional,intent(in) :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer                        :: ilat,Nineq,Nsect
+    logical                        :: check_dim
+    character(len=5)               :: tmp_suffix
+    integer                        :: MPI_ERR
+    !
     !
     Nineq = size(bath,1)
-    if(Nineq > Nlat)stop "init_lattice_bath error: size[bath,1] > Nlat"
-    call setup_ed_dimensions() ! < Nsectors this is called first to allocate the following arrays
-    if(allocated(neigen_sectorii))deallocate(neigen_sectorii)
-    if(allocated(neigen_totalii))deallocate(neigen_totalii)
-    allocate(neigen_sectorii(Nineq,Nsectors))
-    allocate(neigen_totalii(Nineq))
-    do ilat=1,Nineq
+    Nsect = get_Nsectors() !< get # sectors to allocate the following array
+    if(allocated(neigen_sectorii))deallocate(neigen_sectorii) ; allocate(neigen_sectorii(Nineq,Nsect))
+    if(allocated(neigen_totalii))deallocate(neigen_totalii) ; allocate(neigen_totalii(Nineq))
+    do ilat=1,Nineq             !all nodes check the bath, u never know...
        if(present(Hloc))then
           check_dim = check_bath_dimension(bath(ilat,:),Hloc(ilat,:,:,:,:))
        else
           check_dim = check_bath_dimension(bath(ilat,:))
        endif
        if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+       !
        ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
+       !
        if(present(Hloc))then
-          call ed_init_solver(bath(ilat,:),Hloc(ilat,:,:,:,:),hwband_,Hunit_)
+          call ed_init_solver_single(bath(ilat,:),Hloc(ilat,:,:,:,:))
        else
-          call ed_init_solver(bath(ilat,:),hwband=hwband_,Hunit=Hunit_)
+          call ed_init_solver_single(bath(ilat,:))
        endif
        neigen_sectorii(ilat,:) = neigen_sector(:)
        neigen_totalii(ilat)    = lanc_nstates_total
     end do
-#ifdef _MPI
-    call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-#endif
+    !
     ed_file_suffix=""
+    !
   end subroutine ed_init_solver_lattice
 
+#ifdef _MPI
+  subroutine ed_init_solver_lattice_mpi(MpiComm,bath,Hloc)
+    integer                        :: MpiComm
+    real(8),dimension(:,:)         :: bath ![Nlat][:]
+    complex(8),optional,intent(in) :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer                        :: ilat,Nineq,Nsect
+    logical                        :: check_dim
+    character(len=5)               :: tmp_suffix
+    integer                        :: MPI_ERR
+    !
+    !
+    Nineq = size(bath,1)
+    Nsect = get_Nsectors() !< get # sectors to allocate the following array
+    if(allocated(neigen_sectorii))deallocate(neigen_sectorii) ; allocate(neigen_sectorii(Nineq,Nsect))
+    if(allocated(neigen_totalii))deallocate(neigen_totalii) ; allocate(neigen_totalii(Nineq))
+    do ilat=1,Nineq             !all nodes check the bath, u never know...
+       if(present(Hloc))then
+          check_dim = check_bath_dimension(bath(ilat,:),Hloc(ilat,:,:,:,:))
+       else
+          check_dim = check_bath_dimension(bath(ilat,:))
+       endif
+       if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+       !
+       ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
+       !
+       if(present(Hloc))then
+          call ed_init_solver_single_mpi(MpiComm,bath(ilat,:),Hloc(ilat,:,:,:,:))
+       else
+          call ed_init_solver_single_mpi(MpiComm,bath(ilat,:))
+       endif
+       neigen_sectorii(ilat,:) = neigen_sector(:)
+       neigen_totalii(ilat)    = lanc_nstates_total
+    end do
+    !
+    call MPI_Barrier(MpiComm,MPI_ERR)
+    !
+    ed_file_suffix=""
+    !
+  end subroutine ed_init_solver_lattice_mpi
+#endif
 
 
 
@@ -177,61 +264,279 @@ contains
 
 
 
-  !+------------------------------------------------------------------+
+
+  !+-----------------------------------------------------------------------------+!
   !PURPOSE: solve the impurity problems for a single or many independent
   ! lattice site using ED. 
-  !+------------------------------------------------------------------+
-  subroutine ed_solve_single(bath_,MpiComm)
-    !
-    integer,optional                :: MpiComm
-    !
-    real(8),dimension(:),intent(in) :: bath_
+  !+-----------------------------------------------------------------------------+!
+  !+-----------------------------------------------------------------------------+!
+  !                              SINGLE SITE                                      !
+  !+-----------------------------------------------------------------------------+!
+  subroutine ed_solve_single(bath)
+    integer                         :: MpiComm
+    real(8),dimension(:),intent(in) :: bath
     logical                         :: check
-#ifdef _MPI
-    if(present(MpiComm))then
-       ED_MPI_COMM = MpiComm
-    else
-       ED_MPI_COMM = MPI_COMM_WORLD
-    end if
-    ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
-    ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
-    ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
-#endif
-    check = check_bath_dimension(bath_,impHloc)
-    if(.not.check)stop "init_ed_solver: wrong bath dimensions"
+    logical                         :: MPI_MASTER=.true.
+    !
+    check = check_bath_dimension(bath)
+    if(.not.check)stop "ED_SOLVE_SINGLE Error: wrong bath dimensions"
+    !
     call allocate_dmft_bath(dmft_bath)
     if(bath_type=="replica")call init_dmft_bath_mask(dmft_bath)
-    call set_dmft_bath(bath_,dmft_bath)
-    if(ED_MPI_ID==0)then
+    call set_dmft_bath(bath,dmft_bath)
+    if(MPI_MASTER)then
        if(ed_verbose<2)call write_dmft_bath(dmft_bath,LOGfile)
        call save_dmft_bath(dmft_bath,used=.true.)
     endif
-    !ASSOCIATE THE GLOBAL PROCEDURES TO THE SPECIFIC ONES
-    !AS DICTATED BY THE INPUT 
-    if(associated(ed_buildh_d))nullify(ed_buildh_d)
-    if(associated(ed_buildh_c))nullify(ed_buildh_c)
+    !
+    !ASSOCIATE THE GLOBAL PROCEDURES
     select case(ed_mode)
     case ('normal')
        ed_buildh_d=>build_H_normal_d
-       ed_buildh_c=>build_H_normal_c
+       ed_buildh_c=>build_H_normal_c       
     case default
        ed_buildh_d=>build_H_all_d
        ed_buildh_c=>build_H_all_c
     end select
+    !
+    spHtimesV_dd => spMatVec_dd
+    spHtimesV_cc => spMatVec_cc
+    lanc_spHtimesV_dd => lanc_spMatVec_dd
+    lanc_spHtimesV_dc => lanc_spMatVec_dc
+    lanc_spHtimesV_cc => lanc_spMatVec_cc
+    !
     !SOLVE THE QUANTUM IMPURITY PROBLEM:
-    call diagonalize_impurity         !find target states by digonalization of Hamiltonian
-    call observables_impurity         !obtain impurity observables as thermal averages.  
-    call buildgf_impurity             !build the one-particle impurity Green's functions  & Self-energy
-    if(chiflag)call buildchi_impurity !build the local susceptibilities (spin [todo charge])
-    call local_energy_impurity        !obtain the local energy of the effective impurity problem.
+    call diagonalize_impurity()         !find target states by digonalization of Hamiltonian
+    call observables_impurity()         !obtain impurity observables as thermal averages.  
+    call buildgf_impurity()             !build the one-particle impurity Green's functions  & Self-energy
+    if(chiflag)call buildchi_impurity() !build the local susceptibilities (spin [todo charge])
+    call local_energy_impurity()        !obtain the local energy of the effective impurity problem.
+    !
     call deallocate_dmft_bath(dmft_bath)   
-    call es_delete_espace(state_list) 
+    call es_delete_espace(state_list)
+    !
+    nullify(ed_buildh_d)
+    nullify(ed_buildh_c)
+    nullify(spHtimesV_dd)
+    nullify(spHtimesV_cc)
+    nullify(lanc_spHtimesV_dd)
+    nullify(lanc_spHtimesV_dc)
+    nullify(lanc_spHtimesV_cc)
   end subroutine ed_solve_single
 
-  subroutine ed_solve_lattice(bath,Hloc,iprint,MpiComm,Uloc_ii,Ust_ii,Jh_ii)
+#ifdef _MPI
+  !+-----------------------------------------------------------------------------+!
+  !                              SINGLE SITE                                      !
+  !+-----------------------------------------------------------------------------+!
+  subroutine ed_solve_single_mpi(MpiComm,bath)
+    integer                         :: MpiComm
+    real(8),dimension(:),intent(in) :: bath
+    logical                         :: check
+    logical                         :: MPI_MASTER=.true.
     !
-    integer,optional :: MpiComm
+    MPI_MASTER = get_Master_MPI(MpiComm)
     !
+    check = check_bath_dimension(bath)
+    if(.not.check)stop "ED_SOLVE_SINGLE Error: wrong bath dimensions"
+    !
+    call allocate_dmft_bath(dmft_bath)
+    if(bath_type=="replica")call init_dmft_bath_mask(dmft_bath)
+    call set_dmft_bath(bath,dmft_bath)
+    if(MPI_MASTER)then
+       if(ed_verbose<2)call write_dmft_bath(dmft_bath,LOGfile)
+       call save_dmft_bath(dmft_bath,used=.true.)
+    endif
+    !
+    !ASSOCIATE THE GLOBAL PROCEDURES
+    select case(ed_mode)
+    case ('normal')
+       ed_buildh_d=>build_H_normal_d
+       ed_buildh_c=>build_H_normal_c       
+    case default
+       ed_buildh_d=>build_H_all_d
+       ed_buildh_c=>build_H_all_c
+    end select
+    !
+    spHtimesV_dd => spMatVec_MPI_dd
+    spHtimesV_cc => spMatVec_MPI_cc
+    lanc_spHtimesV_dd => lanc_spMatVec_MPI_dd
+    lanc_spHtimesV_dc => lanc_spMatVec_MPI_dc
+    lanc_spHtimesV_cc => lanc_spMatVec_MPI_cc
+    !
+    !SET THE LOCAL COMMUNICATORS IN ALL THE RELEVANT PARTS OF THE CODE:
+    call ed_matvec_set_MPI(MpiComm)
+    call ed_hamiltonian_set_MPI(MpiComm)
+    call ed_diag_set_MPI(MpiComm)
+    call ed_observables_set_MPI(MpiComm)
+    call ed_greens_functions_set_MPI(MpiComm)
+    !
+    !SOLVE THE QUANTUM IMPURITY PROBLEM:
+    call diagonalize_impurity()         !find target states by digonalization of Hamiltonian
+    call observables_impurity()         !obtain impurity observables as thermal averages.  
+    call buildgf_impurity()             !build the one-particle impurity Green's functions  & Self-energy
+    if(chiflag)call buildchi_impurity() !build the local susceptibilities (spin [todo charge])
+    call local_energy_impurity()        !obtain the local energy of the effective impurity problem.
+    !
+    call deallocate_dmft_bath(dmft_bath)   
+    call es_delete_espace(state_list)
+    !
+    call ed_matvec_del_MPI()
+    call ed_hamiltonian_del_MPI()
+    call ed_diag_del_MPI()
+    call ed_observables_del_MPI()
+    call ed_greens_functions_del_MPI()    
+    nullify(ed_buildh_d)
+    nullify(ed_buildh_c)
+    nullify(spHtimesV_dd)
+    nullify(spHtimesV_cc)
+    nullify(lanc_spHtimesV_dd)
+    nullify(lanc_spHtimesV_dc)
+    nullify(lanc_spHtimesV_cc)
+  end subroutine ed_solve_single_mpi
+#endif
+
+
+
+
+
+
+
+  !+-----------------------------------------------------------------------------+!
+  !                          INEQUIVALENT SITES                                   !
+  !+-----------------------------------------------------------------------------+!
+  !FALL BACK: DO A VERSION THAT DOES THE SITES IN PARALLEL USING SERIAL ED CODE
+  subroutine ed_solve_lattice(bath,Hloc,iprint,Uloc_ii,Ust_ii,Jh_ii)
+    !inputs
+    real(8)          :: bath(:,:) ![Nlat][Nb]
+    complex(8)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer          :: iprint
+    real(8),optional :: Uloc_ii(size(bath,1),Norb)
+    real(8),optional :: Ust_ii(size(bath,1))
+    real(8),optional :: Jh_ii(size(bath,1))
+    ! 
+    integer          :: i,j,ilat,iorb,jorb,ispin,jspin
+    integer          :: Nsites
+    logical          :: check_dim
+    character(len=5) :: tmp_suffix
+    !
+    logical          :: MPI_MASTER=.true.
+    !
+    ! Check dimensions !
+    Nsites=size(bath,1)
+    !
+    !Allocate the local static observarbles global to the module
+    !One can retrieve these values from suitable routines later on
+    if(allocated(nii))deallocate(nii)
+    if(allocated(dii))deallocate(dii)
+    if(allocated(mii))deallocate(mii)
+    if(allocated(pii))deallocate(pii)
+    if(allocated(eii))deallocate(eii)
+    if(allocated(ddii))deallocate(ddii)
+    allocate(nii(Nsites,Norb))
+    allocate(dii(Nsites,Norb))
+    allocate(mii(Nsites,Norb))
+    allocate(pii(Nsites,Norb))
+    allocate(eii(Nsites,4))
+    allocate(ddii(Nsites,4))
+    !
+    !Allocate the self-energies global to the module
+    !Once can retrieve these functinos from suitable routines later on
+    if(allocated(Smatsii))deallocate(Smatsii)
+    if(allocated(Srealii))deallocate(Srealii)
+    if(allocated(SAmatsii))deallocate(SAmatsii)
+    if(allocated(SArealii))deallocate(SArealii)
+    allocate(Smatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+    allocate(Srealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+    allocate(SAmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+    allocate(SArealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+    !
+    !Allocate the imp GF global to the module
+    !Once can retrieve these functinos from suitable routines later on
+    if(allocated(Gmatsii))deallocate(Gmatsii)
+    if(allocated(Grealii))deallocate(Grealii)
+    if(allocated(Fmatsii))deallocate(Fmatsii)
+    if(allocated(Frealii))deallocate(Frealii)
+    allocate(Gmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+    allocate(Grealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+    allocate(Fmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+    allocate(Frealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+    !
+    if(size(neigen_sectorii,1)<Nsites)stop "ed_solve_lattice error: size(neigen_sectorii,1)<Nsites"
+    if(size(neigen_totalii)<Nsites)stop "ed_solve_lattice error: size(neigen_totalii,1)<Nsites"
+    !
+    !Check the dimensions of the bath are ok:
+    do ilat=1,Nsites
+       check_dim = check_bath_dimension(bath(ilat,:))
+       if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+    end do
+    Smatsii  = zero 
+    Srealii  = zero 
+    SAmatsii = zero 
+    SArealii = zero 
+    Gmatsii  = zero 
+    Grealii  = zero 
+    Fmatsii  = zero 
+    Frealii  = zero 
+    nii      = 0d0  
+    dii      = 0d0  
+    mii      = 0d0  
+    pii      = 0d0  
+    eii      = 0d0  
+    ddii     = 0d0  
+    !
+    call start_timer
+    !
+    do ilat = 1, Nsites
+       write(*,*)" solves site: "//reg(txtfy(ilat,Npad=4))
+       !
+       ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
+       !
+       !If required set the local value of U per each site
+       if(present(Uloc_ii))Uloc(1:Norb) = Uloc_ii(ilat,1:Norb)
+       if(present(Ust_ii)) Ust          = Ust_ii(ilat) 
+       if(present(Jh_ii))  Jh           = Jh_ii(ilat) 
+       !
+       !Set the local part of the Hamiltonian.
+       call set_Hloc(Hloc(ilat,:,:,:,:))
+       !
+       !Solve the impurity problem for the ilat-th site
+       neigen_sector(:)   = neigen_sectorii(ilat,:)
+       lanc_nstates_total = neigen_totalii(ilat)
+       !
+       !Call ed_solve in SERIAL MODE!! This is parallel on the ineq. sites
+       call ed_solve_single(bath(ilat,:))
+       !
+       neigen_sectorii(ilat,:)   = neigen_sector(:)
+       neigen_totalii(ilat)      = lanc_nstates_total
+       Smatsii(ilat,:,:,:,:,:)  = impSmats(:,:,:,:,:)
+       Srealii(ilat,:,:,:,:,:)  = impSreal(:,:,:,:,:)
+       SAmatsii(ilat,:,:,:,:,:) = impSAmats(:,:,:,:,:)
+       SArealii(ilat,:,:,:,:,:) = impSAreal(:,:,:,:,:)
+       Gmatsii(ilat,:,:,:,:,:)  = impGmats(:,:,:,:,:)
+       Grealii(ilat,:,:,:,:,:)  = impGreal(:,:,:,:,:)
+       Fmatsii(ilat,:,:,:,:,:)  = impFmats(:,:,:,:,:)
+       Frealii(ilat,:,:,:,:,:)  = impFreal(:,:,:,:,:)
+       nii(ilat,1:Norb)       = ed_dens(1:Norb)
+       dii(ilat,1:Norb)       = ed_docc(1:Norb)
+       mii(ilat,1:Norb)       = ed_dens_up(1:Norb)-ed_dens_dw(1:Norb)
+       pii(ilat,1:Norb)       = ed_phisc(1:Norb)
+       eii(ilat,:)            = [ed_Epot,ed_Eint,ed_Ehartree,ed_Eknot]
+       ddii(ilat,:)           = [ed_Dust,ed_Dund,ed_Dse,ed_Dph]
+    enddo
+    !
+    call stop_timer
+    !
+    ed_file_suffix=""
+    !
+    call ed_print_impSigma(iprint)
+    !
+  end subroutine ed_solve_lattice
+
+
+  !FALL BACK: DO A VERSION THAT DOES THE SITES IN PARALLEL USING SERIAL ED CODE
+#ifdef _MPI
+  subroutine ed_solve_lattice_mpi(MpiComm,bath,Hloc,iprint,Uloc_ii,Ust_ii,Jh_ii)
+    integer          :: MpiComm
     !inputs
     real(8)          :: bath(:,:) ![Nlat][Nb]
     complex(8)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
@@ -263,31 +568,18 @@ contains
     logical          :: check_dim
     character(len=5) :: tmp_suffix
     !
-    integer          :: MPI_COLOR
-    integer          :: MPI_COLOR_RANK
-    integer          :: MPI_COLOR_SIZE
-    integer          :: MPI_COLOR_COMM
-    logical          :: MPI_COLOR_MASTER
+    integer          :: MPI_ID=0
+    integer          :: MPI_SIZE=1
+    logical          :: MPI_MASTER=.true.
     !
-    integer          :: MPI_MASTERS_COLOR
-    integer          :: MPI_MASTERS_RANK
-    integer          :: MPI_MASTERS_SIZE
-    integer          :: MPI_MASTERS_COMM
+    integer          :: mpi_err 
     !
-#ifdef _MPI
-    if(present(MpiComm))then
-       ED_MPI_COMM = MpiComm
-    else
-       ED_MPI_COMM = MPI_COMM_WORLD
-    end if
-    ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
-    ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
-    ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
-#endif
+    MPI_ID     = get_Rank_MPI(MpiComm)
+    MPI_SIZE   = get_Size_MPI(MpiComm)
+    MPI_MASTER = get_Master_MPI(MpiComm)
     !
     ! Check dimensions !
     Nsites=size(bath,1)
-    print*,Nsites,ED_MPI_ID
     !
     !Allocate the local static observarbles global to the module
     !One can retrieve these values from suitable routines later on
@@ -332,72 +624,31 @@ contains
     neigen_totaltmp  = 0
     !
     !Check the dimensions of the bath are ok:
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
+    do ilat=1+MPI_ID,Nsites,MPI_SIZE
        check_dim = check_bath_dimension(bath(ilat,:))
        if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
     end do
-    Smatsii  = zero ; Smats_tmp  = zero
-    Srealii  = zero ; Sreal_tmp  = zero
-    SAmatsii = zero ; SAmats_tmp = zero
-    SArealii = zero ; SAreal_tmp = zero
-    Gmatsii  = zero ; Gmats_tmp  = zero
-    Grealii  = zero ; Greal_tmp  = zero
-    Fmatsii  = zero ; Fmats_tmp  = zero
-    Frealii  = zero ; Freal_tmp  = zero
-    nii      = 0d0  ; nii_tmp    = 0d0
-    dii      = 0d0  ; dii_tmp    = 0d0
-    mii      = 0d0  ; mii_tmp    = 0d0
-    pii      = 0d0  ; pii_tmp    = 0d0
-    eii      = 0d0  ; eii_tmp    = 0d0
-    ddii     = 0d0  ; ddii_tmp   = 0d0
+    Smats_tmp  = zero
+    Sreal_tmp  = zero
+    SAmats_tmp = zero
+    SAreal_tmp = zero
+    Gmats_tmp  = zero
+    Greal_tmp  = zero
+    Fmats_tmp  = zero
+    Freal_tmp  = zero
+    nii_tmp    = 0d0
+    dii_tmp    = 0d0
+    mii_tmp    = 0d0
+    pii_tmp    = 0d0
+    eii_tmp    = 0d0
+    ddii_tmp   = 0d0
     !
-    if(ED_MPI_MASTER)call start_timer
-    if(.not.ED_MPI_MASTER)LOGfile = 800+ED_MPI_ID
+    if(MPI_MASTER)call start_timer
+    if(.not.MPI_MASTER)LOGfile = 800+MPI_ID
     !
-#ifdef _MPI
-    if(MPI_Colors==0.OR.MPI_Colors>ED_MPI_SIZE)MPI_Colors=ED_MPI_SIZE
-    if(ED_MPI_SIZE<2)MPI_Colors=1
-    if(ED_MPI_MASTER)then
-       write(LOGfile,*)"MPI_SIZE      =",ED_MPI_SIZE
-       write(LOGfile,*)"MPI_COLORS    =",MPI_Colors
-       write(LOGfile,*)"MPI_COLOR_SIZE=",ED_MPI_SIZE/MPI_Colors
-    endif
-    !
-    MPI_COLOR = MPI_UNDEFINED
-    MPI_COLOR = mod(ED_MPI_ID,MPI_Colors)
-    !
-    !Split the user provided communicator into MPI_Colors groups.
-    !Each group (or color) communicate via the MPI communicator MPI_Color_Comm
-    call MPI_Comm_split(ED_MPI_COMM, MPI_Color, ED_MPI_ID, MPI_Color_Comm, ED_MPI_ERR)
-    MPI_COLOR_SIZE=get_Size_MPI(MPI_COLOR_COMM)
-    MPI_COLOR_RANK=get_Rank_MPI(MPI_COLOR_COMM)
-    MPI_COLOR_MASTER=get_Master_MPI(MPI_COLOR_COMM)
-    do i=0,ED_MPI_SIZE-1
-       if(ED_MPI_ID==i)write(*,*)ED_MPI_ID," is now ",MPI_COLOR_RANK," in color group: ",MPI_Color
-       call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-    enddo
-    call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-    if(ED_MPI_MASTER)write(*,*)""
-#else
-    MPI_Colors=1
-    MPI_Color=0
-    MPI_COLOR_SIZE=1
-    MPI_COLOR_RANK=0
-    MPI_COLOR_MASTER=.true.
-#endif
-
-    ! call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-    ! do i=0,ED_MPI_SIZE-1
-    !    if(ED_MPI_ID==i)write(*,*)ED_MPI_ID,MPI_Color,MPI_Colors
-    !    call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-    ! enddo
-    ! call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-    ! write(*,*)""
-
-    do ilat=1+MPI_Color,Nsites,MPI_Colors
-       if(MPI_COLOR_MASTER)write(*,*)"Solving site:"//reg(txtfy(ilat,Npad=4))//" by group: "//txtfy(mpi_color)
-       write(*,*)reg(txtfy(ED_MPI_ID))//" solves site: "//reg(txtfy(ilat,Npad=4))//" as "//reg(txtfy(MPI_COLOR_RANK))//" in group: "//txtfy(mpi_color)
-
+    do ilat = 1 + MPI_ID, Nsites, MPI_SIZE
+       write(*,*)reg(txtfy(MPI_ID))//" solves site: "//reg(txtfy(ilat,Npad=4))
+       !
        ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
        !
        !If required set the local value of U per each site
@@ -411,12 +662,10 @@ contains
        !Solve the impurity problem for the ilat-th site
        neigen_sector(:)   = neigen_sectorii(ilat,:)
        lanc_nstates_total = neigen_totalii(ilat)
-#ifdef _MPI       
-       call ed_solve_single(bath(ilat,:), MpiComm=MPI_COLOR_COMM)
-       print*,ED_MPI_ID,MPI_COLOR_RANK,ed_dens(1)
-#else
+       !
+       !Call ed_solve in SERIAL MODE!! This is parallel on the ineq. sites
        call ed_solve_single(bath(ilat,:))
-#endif
+       !
        neigen_sectortmp(ilat,:)   = neigen_sector(:)
        neigen_totaltmp(ilat)      = lanc_nstates_total
        Smats_tmp(ilat,:,:,:,:,:)  = impSmats(:,:,:,:,:)
@@ -433,131 +682,61 @@ contains
        pii_tmp(ilat,1:Norb)       = ed_phisc(1:Norb)
        eii_tmp(ilat,:)            = [ed_Epot,ed_Eint,ed_Ehartree,ed_Eknot]
        ddii_tmp(ilat,:)           = [ed_Dust,ed_Dund,ed_Dse,ed_Dph]
-
     enddo
-
-    call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
-
-    if(ED_MPI_MASTER)call stop_timer
+    !
+    call MPI_Barrier(MpiComm,MPI_ERR)
+    !
+    if(MPI_MASTER)call stop_timer
+    !
     ed_file_suffix=""
-
-#ifdef _MPI
-    !Now we need to collect the results: This is done in three steps (I could not realize
-    !a better strategy so far):
-    !1. We split the original communicators in  masters/non-masters, i.e. the processes
-    !    with color_rank 0 or >0. By construction the overall master (ED_MPI_ID=0)
-    !    belongs to this group. 
-    !2. We perform an AllReduce operation among these two groups. This will merge the
-    !    copies on each master into a single array. The copies on the slaves are identical
-    !    to that of their master so we can disregard them.
-    !3. We let the overall master (ED_MPI_ID=0) Bcast the result of the reduction to
-    !    all the other nodes.
+    !
     neigen_sectorii=0
     neigen_totalii =0
     !
+    Smatsii  = zero 
+    Srealii  = zero 
+    SAmatsii = zero 
+    SArealii = zero 
+    Gmatsii  = zero 
+    Grealii  = zero 
+    Fmatsii  = zero 
+    Frealii  = zero 
+    nii      = 0d0  
+    dii      = 0d0  
+    mii      = 0d0  
+    pii      = 0d0  
+    eii      = 0d0  
+    ddii     = 0d0  
+    call MPI_ALLREDUCE(neigen_sectortmp,neigen_sectorii,Nsites*Nsectors,MPI_INTEGER,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(neigen_totaltmp,neigen_totalii,Nsites,MPI_INTEGER,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(Smats_tmp,Smatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(Sreal_tmp,Srealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(SAmats_tmp,SAmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(SAreal_tmp,SArealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(Gmats_tmp,Gmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(Greal_tmp,Grealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(Fmats_tmp,Fmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(Freal_tmp,Frealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(nii_tmp,nii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(dii_tmp,dii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(mii_tmp,mii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(pii_tmp,pii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(eii_tmp,eii,Nsites*4,MPI_DOUBLE_PRECISION,MPI_SUM,MpiComm,mpi_err)
+    call MPI_ALLREDUCE(ddii_tmp,ddii,Nsites*4,MPI_DOUBLE_PRECISION,MPI_SUM,MpiComm,mpi_err)
     !
-    !1. split ED_MPI_COMM into MASTER/NON-MASTERS
-    if(ED_MPI_MASTER)write(LOGfile,"(A)")"Creating Masters/non-Masters group:"
-    MPI_Masters_Color=1
-    if(MPI_COLOR_MASTER)MPI_Masters_Color=0
-    call MPI_Comm_Split(ED_MPI_COMM, MPI_Masters_Color, ED_MPI_ID, MPI_MASTERS_COMM, ED_MPI_ERR)
-    do j=0,ED_MPI_SIZE-1
-       MPI_MASTERS_RANK=get_Rank_MPI(MPI_MASTERS_COMM)
-       if(MPI_COLOR_MASTER)then
-          IF(ED_MPI_ID==j)write(*,"(A)")reg(str(ED_MPI_ID))//"(~ master in group"//reg(str(MPI_Color))//&
-               ") is now "//reg(str(MPI_MASTERS_RANK))//" in masters group: "//reg(str(MPI_Masters_Color))
-       else
-          IF(ED_MPI_ID==j)write(*,"(A)")reg(str(ED_MPI_ID))//"(~ slave in group"//reg(str(MPI_Color))//&
-               ") is now "//reg(str(MPI_MASTERS_RANK))//" in NON-masters group: "//reg(str(MPI_Masters_Color))
-       endif
-       call MPI_Barrier(ED_MPI_COMM, ED_MPI_ERR)
-    enddo
-    call MPI_Barrier(ED_MPI_COMM, ED_MPI_ERR)
-    if(ED_MPI_MASTER)write(LOGfile,"(A)")""
+    if(MPI_MASTER)call ed_print_impSigma(iprint)
     !
-    !2. Reduce in the masters/non-masters group
-    call MPI_AllReduce(neigen_sectortmp, neigen_sectorii, Nsites*Nsectors, MPI_INTEGER, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(neigen_totaltmp, neigen_totalii, Nsites, MPI_INTEGER, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(Smats_tmp, Smatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(Sreal_tmp, Srealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(SAmats_tmp, SAmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(SAreal_tmp, SArealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(Gmats_tmp, Gmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(Greal_tmp, Grealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(Fmats_tmp, Fmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(Freal_tmp, Frealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(nii_tmp, nii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(dii_tmp, dii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(mii_tmp, mii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(pii_tmp, pii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(eii_tmp, eii, Nsites*4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    call MPI_AllReduce(ddii_tmp, ddii, Nsites*4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
-    !
-    !3. have the overall master bcast the results
-    call MPI_Bcast(neigen_sectorii, Nsites*Nsectors, MPI_INTEGER, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(neigen_totalii, Nsites, MPI_INTEGER, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(Smatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(Srealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(SAmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(SArealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(Gmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(Grealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(Fmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(Frealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(nii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(dii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(mii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(pii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(eii, Nsites*4, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Bcast(ddii, Nsites*4, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
-    !
-    !
-    ! call MPI_ALLREDUCE(neigen_sectortmp,neigen_sectorii,Nsites*Nsectors,MPI_INTEGER,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(neigen_totaltmp,neigen_totalii,Nsites,MPI_INTEGER,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(Smats_tmp,Smatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(Sreal_tmp,Srealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(SAmats_tmp,SAmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(SAreal_tmp,SArealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(Gmats_tmp,Gmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(Greal_tmp,Grealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(Fmats_tmp,Fmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(Freal_tmp,Frealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(nii_tmp,nii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(dii_tmp,dii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(mii_tmp,mii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(pii_tmp,pii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(eii_tmp,eii,Nsites*4,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    ! call MPI_ALLREDUCE(ddii_tmp,ddii,Nsites*4,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    !
-    !
-    if(present(MpiComm))then
-       ED_MPI_COMM=MpiComm
-    else
-       ED_MPI_COMM=MPI_COMM_WORLD
-    endif
-    call MPI_Barrier(ED_MPI_COMM, ED_MPI_ERR)
-    call MPI_Comm_Free(MPI_MASTERS_COMM,ED_MPI_ERR)
-    call MPI_Comm_Free(MPI_COLOR_COMM,ED_MPI_ERR)
-#else
-    neigen_sectorii=neigen_sectortmp
-    neigen_totalii =neigen_totaltmp
-    Smatsii  =  Smats_tmp
-    Srealii  =  Sreal_tmp
-    SAmatsii = SAmats_tmp
-    SArealii = SAreal_tmp
-    Gmatsii  = Gmats_tmp
-    Grealii  = Greal_tmp
-    Fmatsii  = Fmats_tmp
-    Frealii  = Freal_tmp
-    nii      = nii_tmp
-    dii      = dii_tmp
-    mii      = mii_tmp
-    pii      = pii_tmp
-    eii      = eii_tmp
-    ddii     = ddii_tmp
+  end subroutine ed_solve_lattice_mpi
 #endif
-    call ed_print_impSigma(iprint)
-  end subroutine ed_solve_lattice
+
+
+
+
+
+
+
+
+
 
 
 
@@ -572,40 +751,121 @@ contains
   !+------------------------------------------------------------------+
   !PURPOSE: Rebuild the Self-energy (normal mode only) 
   !+------------------------------------------------------------------+
-  subroutine ed_rebuild_sigma_single(bath_,MpiComm)
-    !
-    integer,optional                :: MpiComm
-    !
-    real(8),dimension(:),intent(in) :: bath_
+  subroutine ed_rebuild_sigma_single(bath)
+    real(8),dimension(:),intent(in) :: bath
     logical                         :: check
-#ifdef _MPI
-    if(present(MpiComm))then
-       ED_MPI_COMM = MpiComm
-    else
-       ED_MPI_COMM = MPI_COMM_WORLD
-    end if
-    ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
-    ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
-    ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
-#endif
+    logical                         :: MPI_MASTER=.true.
+    !
     if(ed_mode/="normal")stop "WARNING: ed_rebuild_sigma works only in normal mode"
-    check = check_bath_dimension(bath_)
+    check = check_bath_dimension(bath)
     if(.not.check)stop "init_ed_solver: wrong bath dimensions"
     call allocate_dmft_bath(dmft_bath)
-    call set_dmft_bath(bath_,dmft_bath)
-    if(ED_MPI_MASTER)then
+    call set_dmft_bath(bath,dmft_bath)
+    if(MPI_MASTER)then
        if(ed_verbose<2)call write_dmft_bath(dmft_bath,LOGfile)
        call save_dmft_bath(dmft_bath,used=.true.)
     endif
-    call rebuildgf_impurity             !build the one-particle impurity Green's functions & Self-energy
+    !
+    call rebuildgf_impurity()             !build the one-particle impurity Green's functions & Self-energy
+    !
     call deallocate_dmft_bath(dmft_bath)   
   end subroutine ed_rebuild_sigma_single
 
+#ifdef _MPI
+  subroutine ed_rebuild_sigma_single_mpi(MpiComm,bath)
+    integer                         :: MpiComm
+    real(8),dimension(:),intent(in) :: bath
+    logical                         :: check
+    logical                         :: MPI_MASTER=.true.
+    !
+    MPI_MASTER = get_Master_MPI(MpiComm)
+    !
+    if(ed_mode/="normal")stop "WARNING: ed_rebuild_sigma works only in normal mode"
+    check = check_bath_dimension(bath)
+    if(.not.check)stop "init_ed_solver: wrong bath dimensions"
+    call allocate_dmft_bath(dmft_bath)
+    call set_dmft_bath(bath,dmft_bath)
+    if(MPI_MASTER)then
+       if(ed_verbose<2)call write_dmft_bath(dmft_bath,LOGfile)
+       call save_dmft_bath(dmft_bath,used=.true.)
+    endif
+    !
+    !SET THE LOCAL COMMUNICATORS IN ALL THE RELEVANT PARTS OF THE CODE:
+    call ed_greens_functions_set_MPI(MpiComm)
+    !
+    call rebuildgf_impurity()             !build the one-particle impurity Green's functions & Self-energy
+    !
+    call ed_greens_functions_del_MPI()
+    call deallocate_dmft_bath(dmft_bath)   
+  end subroutine ed_rebuild_sigma_single_mpi
+#endif
 
-  subroutine ed_rebuild_sigma_lattice(bath,Hloc,iprint,MpiComm)
+
+
+
+  subroutine ed_rebuild_sigma_lattice(bath,Hloc,iprint)
+    real(8)          :: bath(:,:) ![Nlat][Nb]
+    complex(8)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+    integer          :: iprint
+    ! 
+    integer          :: ilat,iorb,jorb,ispin,jspin,i
+    integer          :: Nsites
+    logical          :: check_dim
+    character(len=5) :: tmp_suffix
     !
-    integer,optional :: MpiComm
+    ! Check dimensions !
+    Nsites=size(bath,1)
     !
+    !Allocate the self-energies global to the module
+    !Once can retrieve these functinos from suitable routines later on
+    if(allocated(Smatsii))deallocate(Smatsii)
+    if(allocated(Srealii))deallocate(Srealii)
+    if(allocated(SAmatsii))deallocate(SAmatsii)
+    if(allocated(SArealii))deallocate(SArealii)
+    allocate(Smatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+    allocate(Srealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+    allocate(SAmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+    allocate(SArealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+    Smatsii  = zero
+    Srealii  = zero
+    SAmatsii = zero
+    SArealii = zero
+    !
+    !Check the dimensions of the bath are ok:
+    write(LOGfile,*)"Rebuilding Sigma: have you moved .used bath files to .restart ones?! "
+    call sleep(3)
+    do ilat = 1, Nsites
+       check_dim = check_bath_dimension(bath(ilat,:))
+       if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+    end do
+    !
+    call start_timer
+    do ilat = 1, Nsites
+       write(LOGfile,*)"Solving site:"//reg(txtfy(ilat,Npad=4))
+       !
+       ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
+       !
+       !Set the local part of the Hamiltonian.
+       call set_Hloc(Hloc(ilat,:,:,:,:))
+       ! 
+       !Rebuild for the ilat-th site, this can be done serially.
+       call ed_rebuild_sigma_single(bath(ilat,:))
+       Smatsii(ilat,:,:,:,:,:)  = impSmats(:,:,:,:,:)
+       Srealii(ilat,:,:,:,:,:)  = impSreal(:,:,:,:,:)
+       SAmatsii(ilat,:,:,:,:,:) = impSAmats(:,:,:,:,:)
+       SArealii(ilat,:,:,:,:,:) = impSAreal(:,:,:,:,:)
+    enddo
+    call stop_timer
+    !
+    ed_file_suffix=""
+    !
+    call ed_print_impSigma(iprint)
+    !
+  end subroutine ed_rebuild_sigma_lattice
+
+#ifdef _MPI
+  subroutine ed_rebuild_sigma_lattice_mpi(MpiComm,bath,Hloc,iprint)
+    integer          :: MpiComm
     real(8)          :: bath(:,:) ![Nlat][Nb]
     complex(8)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
     integer          :: iprint
@@ -619,17 +879,15 @@ contains
     integer          :: Nsites
     logical          :: check_dim
     character(len=5) :: tmp_suffix
-#ifdef _MPI
-    if(present(MpiComm))then
-       ED_MPI_COMM = MpiComm
-    else
-       ED_MPI_COMM = MPI_COMM_WORLD
-    end if
-    ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
-    ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
-    ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
-#endif
     !
+    integer          :: MPI_ID=0
+    integer          :: MPI_SIZE=1
+    logical          :: MPI_MASTER=.true.
+    integer          :: MPI_ERR
+    !
+    MPI_ID = get_Rank_MPI(MpiComm)
+    MPI_SIZE= get_Size_MPI(MpiComm)
+    MPI_MASTER = get_Master_MPI(MpiComm)
     ! Check dimensions !
     Nsites=size(bath,1)
     !
@@ -645,60 +903,518 @@ contains
     allocate(SArealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
     !
     !Check the dimensions of the bath are ok:
-    if(ED_MPI_ID==0)then
+    if(MPI_MASTER)then
        write(LOGfile,*)"Rebuilding Sigma: have you moved .used bath files to .restart ones?! "
        call sleep(3)
     end if
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
+    do ilat = 1 + MPI_ID, Nsites, MPI_SIZE
        check_dim = check_bath_dimension(bath(ilat,:))
        if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
     end do
-    Smatsii  = zero ; Smats_tmp  = zero
-    Srealii  = zero ; Sreal_tmp  = zero
-    SAmatsii = zero ; SAmats_tmp = zero
-    SArealii = zero ; SAreal_tmp = zero
+    Smats_tmp  = zero
+    Sreal_tmp  = zero
+    SAmats_tmp = zero
+    SAreal_tmp = zero
     !
-    if(ED_MPI_MASTER)call start_timer
-    if(.not.ED_MPI_MASTER)LOGfile = 800+ED_MPI_ID
-    do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
-       if(ED_MPI_MASTER)write(LOGfile,*)"Solving site:"//reg(txtfy(ilat,Npad=4))
+    if(MPI_MASTER)call start_timer
+    if(.not.MPI_MASTER)LOGfile = 800+MPI_ID
+    do ilat = 1 + MPI_ID, Nsites, MPI_SIZE
+       if(MPI_MASTER)write(LOGfile,*)"Solving site:"//reg(txtfy(ilat,Npad=4))
+       !
        ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
        !
        !Set the local part of the Hamiltonian.
        call set_Hloc(Hloc(ilat,:,:,:,:))
        ! 
-       !Rebuild for the ilat-th site
-       call ed_rebuild_sigma(bath(ilat,:))
+       !Rebuild for the ilat-th site, this can be done serially.
+       call ed_rebuild_sigma_single(bath(ilat,:))
        Smats_tmp(ilat,:,:,:,:,:)  = impSmats(:,:,:,:,:)
        Sreal_tmp(ilat,:,:,:,:,:)  = impSreal(:,:,:,:,:)
        SAmats_tmp(ilat,:,:,:,:,:) = impSAmats(:,:,:,:,:)
        SAreal_tmp(ilat,:,:,:,:,:) = impSAreal(:,:,:,:,:)
     enddo
-    if(ED_MPI_MASTER)call stop_timer
+    if(MPI_MASTER)call stop_timer
+    !
     ed_file_suffix=""
-#ifdef _MPI
-    call MPI_ALLREDUCE(Smats_tmp,Smatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    call MPI_ALLREDUCE(Sreal_tmp,Srealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    call MPI_ALLREDUCE(SAmats_tmp,SAmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-    call MPI_ALLREDUCE(SAreal_tmp,SArealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
-#else
-    Smatsii  =  Smats_tmp
-    Srealii  =  Sreal_tmp
-    SAmatsii = SAmats_tmp
-    SArealii = SAreal_tmp
+    !
+    Smatsii  = zero
+    Srealii  = zero
+    SAmatsii = zero
+    SArealii = zero
+    call MPI_ALLREDUCE(Smats_tmp,Smatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_Err)
+    call MPI_ALLREDUCE(Sreal_tmp,Srealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_Err)
+    call MPI_ALLREDUCE(SAmats_tmp,SAmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_Err)
+    call MPI_ALLREDUCE(SAreal_tmp,SArealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,MpiComm,mpi_Err)
+    !
+    if(MPI_MASTER)call ed_print_impSigma(iprint)
+    !
+  end subroutine ed_rebuild_sigma_lattice_mpi
 #endif
-    call ed_print_impSigma(iprint)
-
-  end subroutine ed_rebuild_sigma_lattice
-
-
-
-
-
-
-
 
 
 
 end module ED_MAIN
 
+
+
+
+
+!   subroutine ed_solve_lattice_mpi(MpiComm,bath,Hloc,iprint,Uloc_ii,Ust_ii,Jh_ii)
+!     integer          :: MpiComm
+!     !inputs
+!     real(8)          :: bath(:,:) ![Nlat][Nb]
+!     complex(8)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+!     integer          :: iprint
+!     real(8),optional :: Uloc_ii(size(bath,1),Norb)
+!     real(8),optional :: Ust_ii(size(bath,1))
+!     real(8),optional :: Jh_ii(size(bath,1))
+!     !MPI  auxiliary vars
+!     complex(8)       :: Smats_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+!     complex(8)       :: Sreal_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lreal)
+!     complex(8)       :: SAmats_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+!     complex(8)       :: SAreal_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lreal)
+!     complex(8)       :: Gmats_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+!     complex(8)       :: Greal_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lreal)
+!     complex(8)       :: Fmats_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lmats)
+!     complex(8)       :: Freal_tmp(size(bath,1),Nspin,Nspin,Norb,Norb,Lreal)
+!     real(8)          :: nii_tmp(size(bath,1),Norb)
+!     real(8)          :: dii_tmp(size(bath,1),Norb)
+!     real(8)          :: mii_tmp(size(bath,1),Norb)
+!     real(8)          :: pii_tmp(size(bath,1),Norb)
+!     real(8)          :: eii_tmp(size(bath,1),4)
+!     real(8)          :: ddii_tmp(size(bath,1),4)
+!     !
+!     integer          :: neigen_sectortmp(size(bath,1),Nsectors)
+!     integer          :: neigen_totaltmp(size(bath,1))
+!     ! 
+!     integer          :: i,j,ilat,iorb,jorb,ispin,jspin
+!     integer          :: Nsites
+!     logical          :: check_dim
+!     character(len=5) :: tmp_suffix
+!     !
+!     integer          :: MPI_COLOR
+!     integer          :: MPI_COLOR_RANK
+!     integer          :: MPI_COLOR_SIZE
+!     integer          :: MPI_COLOR_COMM
+!     logical          :: MPI_COLOR_MASTER
+!     !
+!     integer          :: MPI_MASTERS_COLOR
+!     integer          :: MPI_MASTERS_RANK
+!     integer          :: MPI_MASTERS_SIZE
+!     integer          :: MPI_MASTERS_COMM
+!     !
+! #ifdef _MPI
+!     if(present(MpiComm))then
+!        ED_MPI_COMM = MpiComm
+!     else
+!        ED_MPI_COMM = MPI_COMM_WORLD
+!     end if
+!     ED_MPI_ID     = get_Rank_MPI(ED_MPI_COMM)
+!     ED_MPI_SIZE   = get_Size_MPI(ED_MPI_COMM)
+!     ED_MPI_MASTER = get_Master_MPI(ED_MPI_COMM)
+! #endif
+!     !
+!     ! Check dimensions !
+!     Nsites=size(bath,1)
+!     print*,Nsites,ED_MPI_ID
+!     !
+!     !Allocate the local static observarbles global to the module
+!     !One can retrieve these values from suitable routines later on
+!     if(allocated(nii))deallocate(nii)
+!     if(allocated(dii))deallocate(dii)
+!     if(allocated(mii))deallocate(mii)
+!     if(allocated(pii))deallocate(pii)
+!     if(allocated(eii))deallocate(eii)
+!     if(allocated(ddii))deallocate(ddii)
+!     allocate(nii(Nsites,Norb))
+!     allocate(dii(Nsites,Norb))
+!     allocate(mii(Nsites,Norb))
+!     allocate(pii(Nsites,Norb))
+!     allocate(eii(Nsites,4))
+!     allocate(ddii(Nsites,4))
+!     !
+!     !Allocate the self-energies global to the module
+!     !Once can retrieve these functinos from suitable routines later on
+!     if(allocated(Smatsii))deallocate(Smatsii)
+!     if(allocated(Srealii))deallocate(Srealii)
+!     if(allocated(SAmatsii))deallocate(SAmatsii)
+!     if(allocated(SArealii))deallocate(SArealii)
+!     allocate(Smatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!     allocate(Srealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!     allocate(SAmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!     allocate(SArealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!     !
+!     !Allocate the imp GF global to the module
+!     !Once can retrieve these functinos from suitable routines later on
+!     if(allocated(Gmatsii))deallocate(Gmatsii)
+!     if(allocated(Grealii))deallocate(Grealii)
+!     if(allocated(Fmatsii))deallocate(Fmatsii)
+!     if(allocated(Frealii))deallocate(Frealii)
+!     allocate(Gmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!     allocate(Grealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!     allocate(Fmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!     allocate(Frealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!     !
+!     if(size(neigen_sectorii,1)<Nsites)stop "ed_solve_lattice error: size(neigen_sectorii,1)<Nsites"
+!     if(size(neigen_totalii)<Nsites)stop "ed_solve_lattice error: size(neigen_totalii,1)<Nsites"
+!     neigen_sectortmp = 0
+!     neigen_totaltmp  = 0
+!     !
+!     !Check the dimensions of the bath are ok:
+!     do ilat=1+ED_MPI_ID,Nsites,ED_MPI_SIZE
+!        check_dim = check_bath_dimension(bath(ilat,:))
+!        if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+!     end do
+!     Smatsii  = zero ; Smats_tmp  = zero
+!     Srealii  = zero ; Sreal_tmp  = zero
+!     SAmatsii = zero ; SAmats_tmp = zero
+!     SArealii = zero ; SAreal_tmp = zero
+!     Gmatsii  = zero ; Gmats_tmp  = zero
+!     Grealii  = zero ; Greal_tmp  = zero
+!     Fmatsii  = zero ; Fmats_tmp  = zero
+!     Frealii  = zero ; Freal_tmp  = zero
+!     nii      = 0d0  ; nii_tmp    = 0d0
+!     dii      = 0d0  ; dii_tmp    = 0d0
+!     mii      = 0d0  ; mii_tmp    = 0d0
+!     pii      = 0d0  ; pii_tmp    = 0d0
+!     eii      = 0d0  ; eii_tmp    = 0d0
+!     ddii     = 0d0  ; ddii_tmp   = 0d0
+!     !
+!     if(ED_MPI_MASTER)call start_timer
+!     if(.not.ED_MPI_MASTER)LOGfile = 800+ED_MPI_ID
+!     !
+! #ifdef _MPI
+!     if(MPI_Colors==0.OR.MPI_Colors>ED_MPI_SIZE)MPI_Colors=ED_MPI_SIZE
+!     if(ED_MPI_SIZE<2)MPI_Colors=1
+!     if(ED_MPI_MASTER)then
+!        write(LOGfile,*)"MPI_SIZE      =",ED_MPI_SIZE
+!        write(LOGfile,*)"MPI_COLORS    =",MPI_Colors
+!        write(LOGfile,*)"MPI_COLOR_SIZE=",ED_MPI_SIZE/MPI_Colors
+!     endif
+!     !
+!     MPI_COLOR = MPI_UNDEFINED
+!     MPI_COLOR = mod(ED_MPI_ID,MPI_Colors)
+!     !
+!     !Split the user provided communicator into MPI_Colors groups.
+!     !Each group (or color) communicate via the MPI communicator MPI_Color_Comm
+!     call MPI_Comm_split(ED_MPI_COMM, MPI_Color, ED_MPI_ID, MPI_Color_Comm, ED_MPI_ERR)
+!     MPI_COLOR_SIZE=get_Size_MPI(MPI_COLOR_COMM)
+!     MPI_COLOR_RANK=get_Rank_MPI(MPI_COLOR_COMM)
+!     MPI_COLOR_MASTER=get_Master_MPI(MPI_COLOR_COMM)
+!     do i=0,ED_MPI_SIZE-1
+!        if(ED_MPI_ID==i)write(*,*)ED_MPI_ID," is now ",MPI_COLOR_RANK," in color group: ",MPI_Color
+!        call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
+!     enddo
+!     call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
+!     if(ED_MPI_MASTER)write(*,*)""
+! #else
+!     MPI_Colors=1
+!     MPI_Color=0
+!     MPI_COLOR_SIZE=1
+!     MPI_COLOR_RANK=0
+!     MPI_COLOR_MASTER=.true.
+! #endif
+!     ! call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
+!     ! do i=0,ED_MPI_SIZE-1
+!     !    if(ED_MPI_ID==i)write(*,*)ED_MPI_ID,MPI_Color,MPI_Colors
+!     !    call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
+!     ! enddo
+!     ! call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
+!     ! write(*,*)""
+!     do ilat=1+MPI_Color,Nsites,MPI_Colors
+!        !if(MPI_COLOR_MASTER)write(*,*)"Solving site:"//reg(txtfy(ilat,Npad=4))//" by group: "//txtfy(mpi_color)
+!        write(*,*)reg(txtfy(ED_MPI_ID))//" solves site: "//reg(txtfy(ilat,Npad=4))//" as "//reg(txtfy(MPI_COLOR_RANK))//" in group: "//txtfy(mpi_color)
+!        write(100+ED_MPI_ID,*)reg(txtfy(ED_MPI_ID))//" solves site: "//reg(txtfy(ilat,Npad=4))//" as "//reg(txtfy(MPI_COLOR_RANK))//" in group: "//txtfy(mpi_color)
+!        ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
+!        !
+!        !If required set the local value of U per each site
+!        if(present(Uloc_ii))Uloc(1:Norb) = Uloc_ii(ilat,1:Norb)
+!        if(present(Ust_ii)) Ust          = Ust_ii(ilat) 
+!        if(present(Jh_ii))  Jh           = Jh_ii(ilat) 
+!        !
+!        !Set the local part of the Hamiltonian.
+!        call set_Hloc(Hloc(ilat,:,:,:,:))
+!        !
+!        !Solve the impurity problem for the ilat-th site
+!        neigen_sector(:)   = neigen_sectorii(ilat,:)
+!        lanc_nstates_total = neigen_totalii(ilat)
+! #ifdef _MPI
+!        call ed_solve_single(bath(ilat,:), MpiComm=MPI_COLOR_COMM)
+!        print*,"ID,color,n:",ED_MPI_ID,MPI_COLOR_RANK,ed_dens(1)
+! #else
+!        call ed_solve_single(bath(ilat,:))
+! #endif
+!        neigen_sectortmp(ilat,:)   = neigen_sector(:)
+!        neigen_totaltmp(ilat)      = lanc_nstates_total
+!        Smats_tmp(ilat,:,:,:,:,:)  = impSmats(:,:,:,:,:)
+!        Sreal_tmp(ilat,:,:,:,:,:)  = impSreal(:,:,:,:,:)
+!        SAmats_tmp(ilat,:,:,:,:,:) = impSAmats(:,:,:,:,:)
+!        SAreal_tmp(ilat,:,:,:,:,:) = impSAreal(:,:,:,:,:)
+!        Gmats_tmp(ilat,:,:,:,:,:)  = impGmats(:,:,:,:,:)
+!        Greal_tmp(ilat,:,:,:,:,:)  = impGreal(:,:,:,:,:)
+!        Fmats_tmp(ilat,:,:,:,:,:)  = impFmats(:,:,:,:,:)
+!        Freal_tmp(ilat,:,:,:,:,:)  = impFreal(:,:,:,:,:)
+!        nii_tmp(ilat,1:Norb)       = ed_dens(1:Norb)
+!        dii_tmp(ilat,1:Norb)       = ed_docc(1:Norb)
+!        mii_tmp(ilat,1:Norb)       = ed_dens_up(1:Norb)-ed_dens_dw(1:Norb)
+!        pii_tmp(ilat,1:Norb)       = ed_phisc(1:Norb)
+!        eii_tmp(ilat,:)            = [ed_Epot,ed_Eint,ed_Ehartree,ed_Eknot]
+!        ddii_tmp(ilat,:)           = [ed_Dust,ed_Dund,ed_Dse,ed_Dph]
+!     enddo
+!     call MPI_Barrier(ED_MPI_COMM,ED_MPI_ERR)
+!     if(ED_MPI_MASTER)call stop_timer
+!     ed_file_suffix=""
+! #ifdef _MPI
+!     !Now we need to collect the results: This is done in three steps (I could not realize
+!     !a better strategy so far):
+!     !1. We split the original communicators in  masters/non-masters, i.e. the processes
+!     !    with color_rank 0 or >0. By construction the overall master (ED_MPI_ID=0)
+!     !    belongs to this group. 
+!     !2. We perform an AllReduce operation among these two groups. This will merge the
+!     !    copies on each master into a single array. The copies on the slaves are identical
+!     !    to that of their master so we can disregard them.
+!     !3. We let the overall master (ED_MPI_ID=0) Bcast the result of the reduction to
+!     !    all the other nodes.
+!     neigen_sectorii=0
+!     neigen_totalii =0
+!     !
+!     !
+!     !1. split ED_MPI_COMM into MASTER/NON-MASTERS
+!     if(ED_MPI_MASTER)write(LOGfile,"(A)")"Creating Masters/non-Masters group:"
+!     MPI_Masters_Color=1
+!     if(MPI_COLOR_MASTER)MPI_Masters_Color=0
+!     call MPI_Comm_Split(ED_MPI_COMM, MPI_Masters_Color, ED_MPI_ID, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     do j=0,ED_MPI_SIZE-1
+!        MPI_MASTERS_RANK=get_Rank_MPI(MPI_MASTERS_COMM)
+!        if(MPI_COLOR_MASTER)then
+!           IF(ED_MPI_ID==j)write(*,"(A)")reg(str(ED_MPI_ID))//"(~ master in group"//reg(str(MPI_Color))//&
+!                ") is now "//reg(str(MPI_MASTERS_RANK))//" in masters group: "//reg(str(MPI_Masters_Color))
+!        else
+!           IF(ED_MPI_ID==j)write(*,"(A)")reg(str(ED_MPI_ID))//"(~ slave in group"//reg(str(MPI_Color))//&
+!                ") is now "//reg(str(MPI_MASTERS_RANK))//" in NON-masters group: "//reg(str(MPI_Masters_Color))
+!        endif
+!        call MPI_Barrier(ED_MPI_COMM, ED_MPI_ERR)
+!     enddo
+!     call MPI_Barrier(ED_MPI_COMM, ED_MPI_ERR)
+!     if(ED_MPI_MASTER)write(LOGfile,"(A)")""
+!     !
+!     !2. Reduce in the masters/non-masters group
+!     call MPI_AllReduce(neigen_sectortmp, neigen_sectorii, Nsites*Nsectors, MPI_INTEGER, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(neigen_totaltmp, neigen_totalii, Nsites, MPI_INTEGER, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(Smats_tmp, Smatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(Sreal_tmp, Srealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(SAmats_tmp, SAmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(SAreal_tmp, SArealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(Gmats_tmp, Gmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(Greal_tmp, Grealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(Fmats_tmp, Fmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(Freal_tmp, Frealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(nii_tmp, nii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(dii_tmp, dii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(mii_tmp, mii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(pii_tmp, pii, Nsites*Norb, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(eii_tmp, eii, Nsites*4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     call MPI_AllReduce(ddii_tmp, ddii, Nsites*4, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_MASTERS_COMM, ED_MPI_ERR)
+!     !
+!     !3. have the overall master bcast the results
+!     call MPI_Bcast(neigen_sectorii, Nsites*Nsectors, MPI_INTEGER, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(neigen_totalii, Nsites, MPI_INTEGER, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(Smatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(Srealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(SAmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(SArealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(Gmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(Grealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(Fmatsii, Nsites*Nspin*Nspin*Norb*Norb*Lmats, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(Frealii, Nsites*Nspin*Nspin*Norb*Norb*Lreal, MPI_DOUBLE_COMPLEX, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(nii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(dii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(mii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(pii, Nsites*Norb, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(eii, Nsites*4, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Bcast(ddii, Nsites*4, MPI_DOUBLE_PRECISION, 0, ED_MPI_COMM, ED_MPI_ERR)
+!     !
+!     !
+!     ! call MPI_ALLREDUCE(neigen_sectortmp,neigen_sectorii,Nsites*Nsectors,MPI_INTEGER,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(neigen_totaltmp,neigen_totalii,Nsites,MPI_INTEGER,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(Smats_tmp,Smatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(Sreal_tmp,Srealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(SAmats_tmp,SAmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(SAreal_tmp,SArealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(Gmats_tmp,Gmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(Greal_tmp,Grealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(Fmats_tmp,Fmatsii,Nsites*Nspin*Nspin*Norb*Norb*Lmats,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(Freal_tmp,Frealii,Nsites*Nspin*Nspin*Norb*Norb*Lreal,MPI_DOUBLE_COMPLEX,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(nii_tmp,nii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(dii_tmp,dii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(mii_tmp,mii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(pii_tmp,pii,Nsites*Norb,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(eii_tmp,eii,Nsites*4,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     ! call MPI_ALLREDUCE(ddii_tmp,ddii,Nsites*4,MPI_DOUBLE_PRECISION,MPI_SUM,ED_MPI_COMM,ED_MPI_ERR)
+!     !
+!     !
+!     if(present(MpiComm))then
+!        ED_MPI_COMM=MpiComm
+!     else
+!        ED_MPI_COMM=MPI_COMM_WORLD
+!     endif
+!     call MPI_Barrier(ED_MPI_COMM, ED_MPI_ERR)
+!     call MPI_Comm_Free(MPI_MASTERS_COMM,ED_MPI_ERR)
+!     call MPI_Comm_Free(MPI_COLOR_COMM,ED_MPI_ERR)
+! #else
+!     neigen_sectorii=neigen_sectortmp
+!     neigen_totalii =neigen_totaltmp
+!     Smatsii  =  Smats_tmp
+!     Srealii  =  Sreal_tmp
+!     SAmatsii = SAmats_tmp
+!     SArealii = SAreal_tmp
+!     Gmatsii  = Gmats_tmp
+!     Grealii  = Greal_tmp
+!     Fmatsii  = Fmats_tmp
+!     Frealii  = Freal_tmp
+!     nii      = nii_tmp
+!     dii      = dii_tmp
+!     mii      = mii_tmp
+!     pii      = pii_tmp
+!     eii      = eii_tmp
+!     ddii     = ddii_tmp
+! #endif
+!     call ed_print_impSigma(iprint)
+!   end subroutine ed_solve_lattice_mpi
+
+
+
+
+
+
+
+
+
+
+! subroutine ed_solve_lattice(bath,Hloc,iprint,Uloc_ii,Ust_ii,Jh_ii)
+!   !inputs
+!   real(8)          :: bath(:,:) ![Nlat][Nb]
+!   complex(8)       :: Hloc(size(bath,1),Nspin,Nspin,Norb,Norb)
+!   integer          :: iprint
+!   real(8),optional :: Uloc_ii(size(bath,1),Norb)
+!   real(8),optional :: Ust_ii(size(bath,1))
+!   real(8),optional :: Jh_ii(size(bath,1))
+!   ! 
+!   integer          :: i,j,ilat,iorb,jorb,ispin,jspin
+!   integer          :: Nsites
+!   logical          :: check_dim
+!   character(len=5) :: tmp_suffix
+!   !
+!   ! Check dimensions !
+!   Nsites=size(bath,1)
+!   !
+!   !Allocate the local static observarbles global to the module
+!   !One can retrieve these values from suitable routines later on
+!   if(allocated(nii))deallocate(nii)
+!   if(allocated(dii))deallocate(dii)
+!   if(allocated(mii))deallocate(mii)
+!   if(allocated(pii))deallocate(pii)
+!   if(allocated(eii))deallocate(eii)
+!   if(allocated(ddii))deallocate(ddii)
+!   allocate(nii(Nsites,Norb))
+!   allocate(dii(Nsites,Norb))
+!   allocate(mii(Nsites,Norb))
+!   allocate(pii(Nsites,Norb))
+!   allocate(eii(Nsites,4))
+!   allocate(ddii(Nsites,4))
+!   !
+!   !Allocate the self-energies global to the module
+!   !Once can retrieve these functinos from suitable routines later on
+!   if(allocated(Smatsii))deallocate(Smatsii)
+!   if(allocated(Srealii))deallocate(Srealii)
+!   if(allocated(SAmatsii))deallocate(SAmatsii)
+!   if(allocated(SArealii))deallocate(SArealii)
+!   allocate(Smatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!   allocate(Srealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!   allocate(SAmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!   allocate(SArealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!   !
+!   !Allocate the imp GF global to the module
+!   !Once can retrieve these functinos from suitable routines later on
+!   if(allocated(Gmatsii))deallocate(Gmatsii)
+!   if(allocated(Grealii))deallocate(Grealii)
+!   if(allocated(Fmatsii))deallocate(Fmatsii)
+!   if(allocated(Frealii))deallocate(Frealii)
+!   allocate(Gmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!   allocate(Grealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!   allocate(Fmatsii(Nsites,Nspin,Nspin,Norb,Norb,Lmats))
+!   allocate(Frealii(Nsites,Nspin,Nspin,Norb,Norb,Lreal))
+!   !
+!   if(size(neigen_sectorii,1)<Nsites)stop "ed_solve_lattice error: size(neigen_sectorii,1)<Nsites"
+!   if(size(neigen_totalii)<Nsites)stop "ed_solve_lattice error: size(neigen_totalii,1)<Nsites"
+!   neigen_sectortmp = 0
+!   neigen_totaltmp  = 0
+!   !
+!   !Check the dimensions of the bath are ok:
+!   do ilat=1,Nsites
+!      check_dim = check_bath_dimension(bath(ilat,:))
+!      if(.not.check_dim) stop "init_lattice_bath: wrong bath size dimension 1 or 2 "
+!   end do
+!   Smatsii  = zero
+!   Srealii  = zero
+!   SAmatsii = zero
+!   SArealii = zero
+!   Gmatsii  = zero
+!   Grealii  = zero
+!   Fmatsii  = zero
+!   Frealii  = zero
+!   nii      = 0d0 
+!   dii      = 0d0 
+!   mii      = 0d0 
+!   pii      = 0d0 
+!   eii      = 0d0 
+!   ddii     = 0d0 
+!   !
+!   call start_timer
+!   !
+!   do ilat=1,Nsites
+!      write(LOGfile,*)""
+!      write(LOGfile,*)""
+!      write(LOGfile,"(A)")"Solving site:"//reg(txtfy(ilat,Npad=4))
+!      !
+!      ed_file_suffix="_site"//reg(txtfy(ilat,Npad=4))
+!      !
+!      !If required set the local value of U per each site
+!      if(present(Uloc_ii))Uloc(1:Norb) = Uloc_ii(ilat,1:Norb)
+!      if(present(Ust_ii)) Ust          = Ust_ii(ilat) 
+!      if(present(Jh_ii))  Jh           = Jh_ii(ilat) 
+!      !
+!      !Set the local part of the Hamiltonian.
+!      call set_Hloc(Hloc(ilat,:,:,:,:))
+!      !
+!      !Solve the impurity problem for the ilat-th site
+!      neigen_sector(:)   = neigen_sectorii(ilat,:)
+!      lanc_nstates_total = neigen_totalii(ilat)
+!      !
+!      call ed_solve_single(bath(ilat,:))
+!      !
+!      neigen_sectorii(ilat,:)   = neigen_sector(:)
+!      neigen_totalii(ilat)      = lanc_nstates_total
+!      Smatsii(ilat,:,:,:,:,:)  = impSmats(:,:,:,:,:)
+!      Srealii(ilat,:,:,:,:,:)  = impSreal(:,:,:,:,:)
+!      SAmatsii(ilat,:,:,:,:,:) = impSAmats(:,:,:,:,:)
+!      SArealii(ilat,:,:,:,:,:) = impSAreal(:,:,:,:,:)
+!      Gmatsii(ilat,:,:,:,:,:)  = impGmats(:,:,:,:,:)
+!      Grealii(ilat,:,:,:,:,:)  = impGreal(:,:,:,:,:)
+!      Fmatsii(ilat,:,:,:,:,:)  = impFmats(:,:,:,:,:)
+!      Frealii(ilat,:,:,:,:,:)  = impFreal(:,:,:,:,:)
+!      nii(ilat,1:Norb)       = ed_dens(1:Norb)
+!      dii(ilat,1:Norb)       = ed_docc(1:Norb)
+!      mii(ilat,1:Norb)       = ed_dens_up(1:Norb)-ed_dens_dw(1:Norb)
+!      pii(ilat,1:Norb)       = ed_phisc(1:Norb)
+!      eii(ilat,:)            = [ed_Epot,ed_Eint,ed_Ehartree,ed_Eknot]
+!      ddii(ilat,:)           = [ed_Dust,ed_Dund,ed_Dse,ed_Dph]
+!   enddo
+!   !
+!   call stop_timer
+!   !
+!   ed_file_suffix=""
+!   !
+!   call ed_print_impSigma(iprint)
+!   !
+! end subroutine ed_solve_lattice

--- a/ED_MATVEC.f90
+++ b/ED_MATVEC.f90
@@ -11,30 +11,64 @@ MODULE ED_MATVEC
   USE ED_INPUT_VARS
   USE ED_VARS_GLOBAL
 #ifdef _MPI
+  USE MPI
   USE SF_MPI
 #endif
   implicit none
   private
 
   !Sparse Matrix-vector product using stored sparse matrix 
-  public  :: spHtimesV_dd
-  public  :: spHtimesV_cc
+  public  :: spMatVec_dd
+  public  :: spMatVec_cc
+#ifdef _MPI
+  public  :: spMatVec_MPI_dd
+  public  :: spMatVec_MPI_cc
+#endif
   !
-  public  :: lanc_spHtimesV_dd
-  public  :: lanc_spHtimesV_dc
-  public  :: lanc_spHtimesV_cc
+  public  :: lanc_spMatVec_dd
+  public  :: lanc_spMatVec_dc
+  public  :: lanc_spMatVec_cc
+#ifdef _MPI
+  public  :: lanc_spMatVec_MPI_dd
+  public  :: lanc_spMatVec_MPI_dc
+  public  :: lanc_spMatVec_MPI_cc
+#endif
+  !
+  public  :: ed_matvec_set_MPI
+  public  :: ed_matvec_del_MPI
 
+#ifdef _MPI
+  integer                      :: MpiComm=MPI_UNDEFINED  
   integer                      :: ierr
-  integer                      :: size
-  logical                      :: master
+  integer                      :: MpiSize
   integer                      :: Q
   integer                      :: R
+#endif
 
   type(sparse_element),pointer :: c
 
 
 
 contains
+
+
+
+  subroutine ed_matvec_set_MPI(comm_)
+#ifdef _MPI
+    integer :: comm_
+    MpiComm = comm_
+#else
+    integer,optional :: comm_
+#endif
+  end subroutine ed_matvec_set_MPI
+
+
+  subroutine ed_matvec_del_MPI()
+#ifdef _MPI
+    MpiComm = MPI_UNDEFINED
+#endif
+  end subroutine ed_matvec_del_MPI
+
 
 
 
@@ -49,73 +83,7 @@ contains
   !PURPOSE  : Perform the matrix-vector product H*v used in the
   ! P/ARPACK Lanczos algorithm using serial double real, complex (MPI)
   !+------------------------------------------------------------------+
-#ifdef _MPI
-  subroutine spHtimesV_dd(Nloc,v,Hv)
-    integer                          :: Nloc
-    real(8),dimension(Nloc)          :: v
-    real(8),dimension(Nloc)          :: Hv
-    integer                          :: N
-    real(8),dimension(:),allocatable :: vin
-    integer                          :: i
-    integer,allocatable,dimension(:) :: SendCounts,Displs
-    N=0
-    call MPI_AllReduce(Nloc,N,1,MPI_Integer,MPI_Sum,ED_MPI_COMM,ierr)
-    size = get_size_MPI(ED_MPI_COMM)
-    Q = get_Q_MPI(ED_MPI_COMM,N)
-    R = get_R_MPI(ED_MPI_COMM,N)
-    allocate(vin(N))
-    vin=0d0
-    allocate(SendCounts(0:size-1),displs(0:size-1))
-    SendCounts(0:)     = Q
-    SendCounts(size-1) = Q+mod(N,size)
-    forall(i=0:size-1)Displs(i)=i*Q
-    call MPI_Allgatherv(v(1:Nloc),Nloc,MPI_Double_Precision,vin,SendCounts,Displs,MPI_Double_Precision,ED_MPI_COMM,ierr)
-    call MPI_Bcast(vin,N,MPI_Double_Precision,0,ED_MPI_COMM,ierr)
-    Hv=0d0
-    do i=1,Nloc
-       c => spH0%row(i)%root%next       
-       matmul: do while(associated(c))
-          Hv(i) = Hv(i) + c%val*vin(c%col)
-          c => c%next
-       end do matmul
-    end do
-    nullify(c)
-  end subroutine spHtimesV_dd
-  !
-  !
-  subroutine spHtimesV_cc(Nloc,v,Hv)
-    integer                             :: Nloc
-    complex(8),dimension(Nloc)          :: v
-    complex(8),dimension(Nloc)          :: Hv
-    integer                             :: i
-    integer                             :: N
-    complex(8),dimension(:),allocatable :: vin
-    integer,allocatable,dimension(:)    :: SendCounts,Displs
-    N=0
-    call MPI_AllReduce(Nloc,N,1,MPI_Integer,MPI_Sum,ED_MPI_COMM,ierr)
-    size = get_size_MPI(ED_MPI_COMM)
-    Q = get_Q_MPI(ED_MPI_COMM,N)
-    R = get_R_MPI(ED_MPI_COMM,N)
-    allocate(vin(N))
-    vin=dcmplx(0d0,0d0)
-    allocate(SendCounts(0:size-1),displs(0:size-1))
-    SendCounts(0:)     = Q
-    SendCounts(size-1) = Q+mod(N,size)
-    forall(i=0:size-1)Displs(i)=i*Q
-    call MPI_Allgatherv(v(1:Nloc),Nloc,MPI_Double_Complex,vin,SendCounts,Displs,MPI_Double_Complex,ED_MPI_COMM,ierr)
-    call MPI_Bcast(vin,N,MPI_Double_Complex,0,ED_MPI_COMM,ierr)
-    Hv=zero
-    do i=1,Nloc                 !==spH0%Nrow
-       c => spH0%row(i)%root%next       
-       matmul: do while(associated(c))
-          Hv(i) = Hv(i) + c%cval*vin(c%col)
-          c => c%next
-       end do matmul
-    end do
-    nullify(c)
-  end subroutine spHtimesV_cc
-#else
-  subroutine spHtimesV_dd(Nloc,v,Hv)
+  subroutine spMatVec_dd(Nloc,v,Hv)
     integer                          :: Nloc
     real(8),dimension(Nloc)          :: v
     real(8),dimension(Nloc)          :: Hv
@@ -129,10 +97,9 @@ contains
        end do matmul
     end do
     nullify(c)
-  end subroutine spHtimesV_dd
-  !
-  !
-  subroutine spHtimesV_cc(Nloc,v,Hv)
+  end subroutine spMatVec_dd
+
+  subroutine spMatVec_cc(Nloc,v,Hv)
     integer                             :: Nloc
     complex(8),dimension(Nloc)          :: v
     complex(8),dimension(Nloc)          :: Hv
@@ -146,7 +113,76 @@ contains
        end do matmul
     end do
     nullify(c)
-  end subroutine spHtimesV_cc
+  end subroutine spMatVec_cc
+
+
+#ifdef _MPI
+  subroutine spMatVec_mpi_dd(Nloc,v,Hv)
+    integer                          :: Nloc
+    real(8),dimension(Nloc)          :: v
+    real(8),dimension(Nloc)          :: Hv
+    integer                          :: N
+    real(8),dimension(:),allocatable :: vin
+    integer                          :: i
+    integer,allocatable,dimension(:) :: SendCounts,Displs
+    N=0
+    if(MpiComm==MPI_UNDEFINED)stop "spHtimesV_dd ERRROR: MpiComm = MPI_UNDEFINED"
+    call MPI_AllReduce(Nloc,N,1,MPI_Integer,MPI_Sum,MpiComm,ierr)
+    MpiSize = get_size_MPI(MpiComm)
+    Q = get_Q_MPI(MpiComm,N)
+    R = get_R_MPI(MpiComm,N)
+    allocate(vin(N))
+    vin=0d0
+    allocate(SendCounts(0:MpiSize-1),displs(0:MpiSize-1))
+    SendCounts(0:)     = Q
+    SendCounts(MpiSize-1) = Q+mod(N,MpiSize)
+    forall(i=0:MpiSize-1)Displs(i)=i*Q
+    call MPI_Allgatherv(v(1:Nloc),Nloc,MPI_Double_Precision,vin,SendCounts,Displs,MPI_Double_Precision,MpiComm,ierr)
+    call MPI_Bcast(vin,N,MPI_Double_Precision,0,MpiComm,ierr)
+    Hv=0d0
+    do i=1,Nloc
+       c => spH0%row(i)%root%next       
+       matmul: do while(associated(c))
+          Hv(i) = Hv(i) + c%val*vin(c%col)
+          c => c%next
+       end do matmul
+    end do
+    nullify(c)
+  end subroutine spMatVec_mpi_dd
+
+
+  subroutine spMatVec_mpi_cc(Nloc,v,Hv)
+    integer                             :: Nloc
+    complex(8),dimension(Nloc)          :: v
+    complex(8),dimension(Nloc)          :: Hv
+    integer                             :: i
+    integer                             :: N
+    complex(8),dimension(:),allocatable :: vin
+    integer,allocatable,dimension(:)    :: SendCounts,Displs
+    N=0
+    if(MpiComm==MPI_UNDEFINED)stop "spHtimesV_cc ERRROR: MpiComm = MPI_UNDEFINED"
+    call MPI_AllReduce(Nloc,N,1,MPI_Integer,MPI_Sum,MpiComm,ierr)
+    MpiSize = get_Size_MPI(MpiComm)
+    Q = get_Q_MPI(MpiComm,N)
+    R = get_R_MPI(MpiComm,N)
+    allocate(vin(N))
+    vin=dcmplx(0d0,0d0)
+    allocate(SendCounts(0:MpiSize-1),displs(0:MpiSize-1))
+    SendCounts(0:)     = Q
+    SendCounts(MpiSize-1) = Q+mod(N,MpiSize)
+    forall(i=0:MpiSize-1)Displs(i)=i*Q
+    call MPI_Allgatherv(v(1:Nloc),Nloc,MPI_Double_Complex,vin,SendCounts,Displs,MPI_Double_Complex,MpiComm,ierr)
+    call MPI_Bcast(vin,N,MPI_Double_Complex,0,MpiComm,ierr)
+    Hv=zero
+    do i=1,Nloc                 !==spH0%Nrow
+       c => spH0%row(i)%root%next       
+       matmul: do while(associated(c))
+          Hv(i) = Hv(i) + c%cval*vin(c%col)
+          c => c%next
+       end do matmul
+    end do
+    nullify(c)
+  end subroutine spMatVec_mpi_cc
 #endif
 
 
@@ -169,105 +205,7 @@ contains
   !PURPOSE  : Perform the matrix-vector product H*v used in the
   ! Plain Lanczos algorithm for GF using MPI
   !+------------------------------------------------------------------+
-#ifdef _MPI
-  subroutine lanc_spHtimesV_dd(N,v,Hv)
-    integer                          :: N
-    real(8),dimension(N)             :: v
-    real(8),dimension(N)             :: Hv
-    integer                          :: i,j
-    integer                          :: Nloc
-    real(8),dimension(:),allocatable :: vout
-    integer,allocatable,dimension(:) :: SendCounts,Displs
-    size = get_size_MPI(ED_MPI_COMM)
-    Q = get_Q_MPI(ED_MPI_COMM,N)
-    R = get_R_MPI(ED_MPI_COMM,N)
-    Nloc = Q+R
-    allocate(vout(Nloc))
-    vout=0d0
-    do i=1,Nloc
-       c => spH0%row(i)%root%next       
-       matmul: do while(associated(c))
-          vout(i) = vout(i) + c%val*v(c%col)
-          c => c%next
-       end do matmul
-    end do
-    nullify(c)
-    allocate(SendCounts(0:size-1),displs(0:size-1))
-    SendCounts(0:)     = Q
-    SendCounts(size-1) = Q+mod(N,size)
-    forall(i=0:size-1)Displs(i)=i*Q
-    Hv=0d0
-    call MPI_Allgatherv(vout(1:Nloc),Nloc,MPI_Double_Precision,Hv,SendCounts,Displs,MPI_Double_Precision,ED_MPI_COMM,ierr)
-    call MPI_Bcast(Hv,N,MPI_Double_Precision,0,ED_MPI_COMM,ierr)
-  end subroutine lanc_spHtimesV_dd
-  !
-  subroutine lanc_spHtimesV_dc(N,v,Hv)
-    integer                             :: N
-    complex(8),dimension(N)             :: v
-    complex(8),dimension(N)             :: Hv
-    integer                             :: i,j
-    integer                             :: Nloc
-    complex(8),dimension(:),allocatable :: vout
-    integer,allocatable,dimension(:)    :: SendCounts,Displs
-    size = get_size_MPI(ED_MPI_COMM)
-    Q = get_Q_MPI(ED_MPI_COMM,N)
-    R = get_R_MPI(ED_MPI_COMM,N)
-    Nloc = Q+R
-    allocate(vout(Nloc))
-    vout=zero
-    do i=1,Nloc
-       c => spH0%row(i)%root%next       
-       matmul: do while(associated(c))
-          vout(i) = vout(i) + c%val*v(c%col)
-          c => c%next
-       end do matmul
-    end do
-    nullify(c)
-    allocate(SendCounts(0:size-1),displs(0:size-1))
-    SendCounts(0:)     = Q
-    SendCounts(size-1) = Q+mod(N,size)
-    forall(i=0:size-1)Displs(i)=i*Q
-    Hv=zero
-    call MPI_Allgatherv(vout(1:Nloc),Nloc,MPI_Double_Complex,Hv,SendCounts,Displs,MPI_Double_Complex,ED_MPI_COMM,ierr)
-    call MPI_Bcast(Hv,N,MPI_Double_Complex,0,ED_MPI_COMM,ierr)
-  end subroutine lanc_spHtimesV_dc
-  !
-  subroutine lanc_spHtimesV_cc(N,v,Hv)
-    integer                             :: N
-    complex(8),dimension(N)             :: v
-    complex(8),dimension(N)             :: Hv
-    integer                             :: i,j
-    integer                             :: Nloc
-    complex(8),dimension(:),allocatable :: vout
-    integer,allocatable,dimension(:)    :: SendCounts,Displs
-    size = get_size_MPI(ED_MPI_COMM)
-    Q = get_Q_MPI(ED_MPI_COMM,N)
-    R = get_R_MPI(ED_MPI_COMM,N)
-    Nloc = Q+R
-    allocate(vout(Nloc))
-    vout=zero
-    do i=1,Nloc
-       c => spH0%row(i)%root%next       
-       matmul: do while(associated(c))
-          vout(i) = vout(i) + c%cval*v(c%col)
-          c => c%next
-       end do matmul
-    end do
-    nullify(c)
-    allocate(SendCounts(0:size-1),displs(0:size-1))
-    SendCounts(0:)     = Q
-    SendCounts(size-1) = Q+mod(N,size)
-    forall(i=0:size-1)Displs(i)=i*Q
-    Hv=zero
-    call MPI_Allgatherv(vout(1:Nloc),Nloc,MPI_Double_Complex,Hv,SendCounts,Displs,MPI_Double_Complex,ED_MPI_COMM,ierr)
-    call MPI_Bcast(Hv,N,MPI_Double_Complex,0,ED_MPI_COMM,ierr)
-  end subroutine lanc_spHtimesV_cc
-  !
-  !
-#else
-  !
-  !
-  subroutine lanc_spHtimesV_dd(N,v,Hv)
+  subroutine lanc_spMatVec_dd(N,v,Hv)
     integer                          :: N
     real(8),dimension(N)             :: v
     real(8),dimension(N)             :: Hv
@@ -281,9 +219,9 @@ contains
        end do matmul
     end do
     nullify(c)
-  end subroutine lanc_spHtimesV_dd
-  !
-  subroutine lanc_spHtimesV_dc(N,v,Hv)
+  end subroutine lanc_spMatVec_dd
+
+  subroutine lanc_spMatVec_dc(N,v,Hv)
     integer                             :: N
     complex(8),dimension(N)             :: v
     complex(8),dimension(N)             :: Hv
@@ -297,9 +235,9 @@ contains
        end do matmul
     end do
     nullify(c)
-  end subroutine lanc_spHtimesV_dc
-  !
-  subroutine lanc_spHtimesV_cc(N,v,Hv)
+  end subroutine lanc_spMatVec_dc
+
+  subroutine lanc_spMatVec_cc(N,v,Hv)
     integer                             :: N
     complex(8),dimension(N)             :: v
     complex(8),dimension(N)             :: Hv
@@ -313,16 +251,109 @@ contains
        end do matmul
     end do
     nullify(c)
-  end subroutine lanc_spHtimesV_cc
-  !
+  end subroutine lanc_spMatVec_cc
+
+
+#ifdef _MPI
+  subroutine lanc_spMatVec_MPI_dd(N,v,Hv)
+    integer                          :: N
+    real(8),dimension(N)             :: v
+    real(8),dimension(N)             :: Hv
+    integer                          :: i,j
+    integer                          :: Nloc
+    real(8),dimension(:),allocatable :: vout
+    integer,allocatable,dimension(:) :: SendCounts,Displs
+    if(MpiComm==MPI_UNDEFINED)stop "spHtimesV_dd ERRROR: MpiComm = MPI_UNDEFINED"
+    MpiSize = get_Size_MPI(MpiComm)
+    Q = get_Q_MPI(MpiComm,N)
+    R = get_R_MPI(MpiComm,N)
+    Nloc = Q+R
+    allocate(vout(Nloc))
+    vout=0d0
+    do i=1,Nloc
+       c => spH0%row(i)%root%next       
+       matmul: do while(associated(c))
+          vout(i) = vout(i) + c%val*v(c%col)
+          c => c%next
+       end do matmul
+    end do
+    nullify(c)
+    allocate(SendCounts(0:MpiSize-1),displs(0:MpiSize-1))
+    SendCounts(0:)     = Q
+    SendCounts(MpiSize-1) = Q+mod(N,MpiSize)
+    forall(i=0:MpiSize-1)Displs(i)=i*Q
+    Hv=0d0
+    call MPI_Allgatherv(vout(1:Nloc),Nloc,MPI_Double_Precision,Hv,SendCounts,Displs,MPI_Double_Precision,MpiComm,ierr)
+    call MPI_Bcast(Hv,N,MPI_Double_Precision,0,MpiComm,ierr)
+  end subroutine lanc_spMatVec_MPI_dd
+
+
+  subroutine lanc_spMatVec_MPI_dc(N,v,Hv)
+    integer                             :: N
+    complex(8),dimension(N)             :: v
+    complex(8),dimension(N)             :: Hv
+    integer                             :: i,j
+    integer                             :: Nloc
+    complex(8),dimension(:),allocatable :: vout
+    integer,allocatable,dimension(:)    :: SendCounts,Displs
+    if(MpiComm==MPI_UNDEFINED)stop "spHtimesV_dd ERRROR: MpiComm = MPI_UNDEFINED"
+    MpiSize = get_Size_MPI(MpiComm)
+    Q = get_Q_MPI(MpiComm,N)
+    R = get_R_MPI(MpiComm,N)
+    Nloc = Q+R
+    allocate(vout(Nloc))
+    vout=zero
+    do i=1,Nloc
+       c => spH0%row(i)%root%next       
+       matmul: do while(associated(c))
+          vout(i) = vout(i) + c%val*v(c%col)
+          c => c%next
+       end do matmul
+    end do
+    nullify(c)
+    allocate(SendCounts(0:MpiSize-1),displs(0:MpiSize-1))
+    SendCounts(0:)     = Q
+    SendCounts(MpiSize-1) = Q+mod(N,MpiSize)
+    forall(i=0:MpiSize-1)Displs(i)=i*Q
+    Hv=zero
+    call MPI_Allgatherv(vout(1:Nloc),Nloc,MPI_Double_Complex,Hv,SendCounts,Displs,MPI_Double_Complex,MpiComm,ierr)
+    call MPI_Bcast(Hv,N,MPI_Double_Complex,0,MpiComm,ierr)
+  end subroutine lanc_spMatVec_MPI_dc
+
+
+  subroutine lanc_spMatVec_MPI_cc(N,v,Hv)
+    integer                             :: N
+    complex(8),dimension(N)             :: v
+    complex(8),dimension(N)             :: Hv
+    integer                             :: i,j
+    integer                             :: Nloc
+    complex(8),dimension(:),allocatable :: vout
+    integer,allocatable,dimension(:)    :: SendCounts,Displs
+    if(MpiComm==MPI_UNDEFINED)stop "spHtimesV_dd ERRROR: MpiComm = MPI_UNDEFINED"
+    MpiSize = get_Size_MPI(MpiComm)
+    Q = get_Q_MPI(MpiComm,N)
+    R = get_R_MPI(MpiComm,N)
+    Nloc = Q+R
+    allocate(vout(Nloc))
+    vout=zero
+    do i=1,Nloc
+       c => spH0%row(i)%root%next       
+       matmul: do while(associated(c))
+          vout(i) = vout(i) + c%cval*v(c%col)
+          c => c%next
+       end do matmul
+    end do
+    nullify(c)
+    allocate(SendCounts(0:MpiSize-1),displs(0:MpiSize-1))
+    SendCounts(0:)     = Q
+    SendCounts(MpiSize-1) = Q+mod(N,MpiSize)
+    forall(i=0:MpiSize-1)Displs(i)=i*Q
+    Hv=zero
+    call MPI_Allgatherv(vout(1:Nloc),Nloc,MPI_Double_Complex,Hv,SendCounts,Displs,MPI_Double_Complex,MpiComm,ierr)
+    call MPI_Bcast(Hv,N,MPI_Double_Complex,0,MpiComm,ierr)
+  end subroutine lanc_spMatVec_MPI_cc
+
 #endif
-
-
-
-
-
-
-
 
 
 END MODULE ED_MATVEC

--- a/ED_MPI2B.f90
+++ b/ED_MPI2B.f90
@@ -1,0 +1,35 @@
+MODULE ED_MPI2B
+#ifdef _MPI
+  USE MPI
+  USE SF_MPI
+#endif
+  implicit none
+
+
+  !MPI Parallel environment variables
+  !PUBLIC
+  !=========================================================
+  integer :: ED_MPI_COMM=MPI_UNDEFINED
+  logical :: ED_MPI_STATUS=.false.
+  integer :: ED_MPI_ID=0
+  integer :: ED_MPI_SIZE=1
+  integer :: ED_MPI_ERR
+  logical :: ED_MPI_MASTER=.true.
+
+
+
+contains
+
+  subroutine ed_set_MPI(comm)
+    integer :: comm
+#ifdef _MPI
+    ED_MPI_COMM = comm
+    ED_MPI_STATUS = .true.
+    ED_MPI_ID = get_Rank_MPI(ED_MPI_COMM)
+    ED_MPI_SIZE=get_Size_MPI(ED_MPI_COMM)
+    ED_MPI_MASTER=get_Master_MPI(ED_MPI_COMM)
+#endif
+  end subroutine ed_set_MPI
+
+
+END MODULE ED_MPI2B

--- a/ED_SPARSE_MATRIX.f90
+++ b/ED_SPARSE_MATRIX.f90
@@ -1,8 +1,5 @@
 MODULE ED_SPARSE_MATRIX
   USE SF_CONSTANTS, only:zero
-#ifdef _MPI
-  USE MPI
-#endif
   implicit none
   private
 
@@ -19,7 +16,7 @@ MODULE ED_SPARSE_MATRIX
      type(sparse_element),pointer          :: root    !head/root of the list\== list itself
   end type sparse_row
   public :: sparse_row
-  
+
   type sparse_matrix
      integer                               :: Nrow
      logical                               :: status=.false.
@@ -34,7 +31,7 @@ MODULE ED_SPARSE_MATRIX
   end interface sp_init_matrix
   public :: sp_init_matrix      !init the sparse matrix   !checked
 
-  
+
   !DELETE SPARSE MATRIX (LL) OR ONE OF ITS ELEMENTS (LL)
   interface sp_delete_matrix
      module procedure sp_delete_matrix_ll
@@ -97,7 +94,7 @@ MODULE ED_SPARSE_MATRIX
   end interface sp_print_matrix
   public :: sp_print_matrix     !print sparse             !checked
 
-  
+
   !TEST
   public :: sp_test_symmetric
 
@@ -112,12 +109,6 @@ MODULE ED_SPARSE_MATRIX
   public :: sp_inquire_element  !inquire an element       !checked
 
 
-
-  ! #ifdef _MPI
-  !   public :: sp_matrix_vector_product_mpi_dd
-  !   public :: sp_matrix_vector_product_mpi_dc
-  !   public :: sp_matrix_vector_product_mpi_cc
-  ! #endif
 
 
 

--- a/ED_VARS_GLOBAL.f90
+++ b/ED_VARS_GLOBAL.f90
@@ -1,10 +1,10 @@
 MODULE ED_VARS_GLOBAL
   USE SF_CONSTANTS
   USE ED_SPARSE_MATRIX
-#ifdef _MPI
-  USE MPI
-  USE SF_MPI
-#endif
+  ! #ifdef _MPI
+  !   USE MPI
+  !   USE SF_MPI
+  ! #endif
   implicit none
 
   !-------------------- EFFECTIVE BATH STRUCTURE ----------------------!
@@ -45,6 +45,27 @@ MODULE ED_VARS_GLOBAL
        integer                            :: isector
        complex(8),dimension(:,:),optional :: Hmat
      end subroutine c_build_hamiltonian
+
+
+     !SPARSE MATRIX-VECTOR PRODUCTS USED IN ED_MATVEC
+     subroutine dd_sparse_HxV(Nloc,v,Hv)
+       integer                 :: Nloc
+       real(8),dimension(Nloc) :: v
+       real(8),dimension(Nloc) :: Hv
+     end subroutine dd_sparse_HxV
+     !
+     subroutine dc_sparse_HxV(Nloc,v,Hv)
+       integer                    :: Nloc
+       complex(8),dimension(Nloc) :: v
+       complex(8),dimension(Nloc) :: Hv
+     end subroutine dc_sparse_HxV
+     !
+     subroutine cc_sparse_HxV(Nloc,v,Hv)
+       integer                    :: Nloc
+       complex(8),dimension(Nloc) :: v
+       complex(8),dimension(Nloc) :: Hv
+     end subroutine cc_sparse_HxV
+
   end interface
 
 
@@ -90,8 +111,14 @@ MODULE ED_VARS_GLOBAL
   !=========================================================  
   type(sparse_matrix)                                :: spH0
   type(sparse_matrix)                                :: spH0up,spH0dw
-  procedure(d_build_hamiltonian),pointer             :: ed_buildH_d
-  procedure(c_build_hamiltonian),pointer             :: ed_buildH_c
+  procedure(d_build_hamiltonian),pointer             :: ed_buildH_d=>null()
+  procedure(c_build_hamiltonian),pointer             :: ed_buildH_c=>null()
+  procedure(dd_sparse_HxV),pointer                   :: spHtimesV_dd=>null()
+  procedure(cc_sparse_HxV),pointer                   :: spHtimesV_cc=>null()
+  procedure(dd_sparse_HxV),pointer                   :: lanc_spHtimesV_dd=>null()
+  procedure(dc_sparse_HxV),pointer                   :: lanc_spHtimesV_dc=>null()
+  procedure(cc_sparse_HxV),pointer                   :: lanc_spHtimesV_cc=>null()
+
 
   !Variables for DIAGONALIZATION
   !PRIVATE
@@ -195,16 +222,16 @@ MODULE ED_VARS_GLOBAL
   complex(8),allocatable,dimension(:)                :: impj_aplha
   complex(8)                                         :: impLdotS
 
-  !MPI Parallel environment variables
-  !PUBLIC
-  !=========================================================
-  integer                                            :: ED_MPI_COMM
-  integer                                            :: ED_MPI_ID=0
-  integer                                            :: ED_MPI_SIZE=1
-  integer                                            :: ED_MPI_ERR
-  logical                                            :: ED_MPI_MASTER=.true.
+  ! !MPI Parallel environment variables
+  ! !PUBLIC
+  ! !=========================================================
+  ! integer                                            :: ED_MPI_COMM
+  ! integer                                            :: ED_MPI_ID=0
+  ! integer                                            :: ED_MPI_SIZE=1
+  ! integer                                            :: ED_MPI_ERR
+  ! logical                                            :: ED_MPI_MASTER=.true.
 
-  
+
 
   !--------------- LATTICE WRAP VARIABLES -----------------!
   !Lattice size:

--- a/ED_WEISS.f90
+++ b/ED_WEISS.f90
@@ -2,6 +2,9 @@ module ED_WEISS
   USE ED_INPUT_VARS
   USE ED_VARS_GLOBAL
   USE ED_AUX_FUNX
+  !
+  USE ED_MPI2B
+  !
   USE SF_IOTOOLS,   only:reg,txtfy,splot,store_data
   USE SF_TIMER
   USE SF_ARRAYS,    only:arange

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,33 @@
 include make.inc
 
-OBJS= ED_SPARSE_MATRIX.o ED_VARS_GLOBAL.o ED_INPUT_VARS.o ED_AUX_FUNX.o ED_IO.o ED_SETUP.o ED_EIGENSPACE.o ED_BATH.o ED_BATH_FUNCTIONS.o ED_MATVEC.o ED_HAMILTONIAN.o ED_GREENS_FUNCTIONS.o ED_OBSERVABLES.o  ED_GLOC.o ED_WEISS.o ED_ENERGY.o ED_CHI2FIT.o ED_DIAG.o ED_MAIN.o DMFT_ED.o
+#MPI FREE:
+#+ED_SPARSE_MATRIX
+#+ED_VARS_GLOBAL
+#+ED_AUX_FUNX
+#+ED_IO
+#+ED_EIGENSPACE
+#+ED_BATH
+#+ED_BATH_FUNCTIONS
 
+#+ED_SETUP: LOCAL MPI in *init_ed_structure*:
+
+
+#MODULE DEFINED MPI:
+#+ED_MATVEC: requires to call *ed_matvec_set/del_MPI* to set MPI_COMM
+#+ED_HAMILTONIAN: requires to call *ed_hamiltonian_set/del_MPI* to set local MPI_COMM
+## USED IN
+#++> ED_DIAG: diagonalize_impurity (top level) has two versions: serial/parallel. It is in charge of setting and deleting MPI in related modules (MATVEC, HAMILTONIAN).
+#             the rest of the module uses MPI implicitly as usual. Where requires pre-processing is used to separete serial and parallel channel
+#
+#++> ED_OBSERVABLES: almost MPI free. observables_impurity (top level) has optional MPI communicator. If MPI is defined communicator is used to set MPI_MASTER.
+#
+#
+
+OBJS= ED_SPARSE_MATRIX.o ED_INPUT_VARS.o ED_VARS_GLOBAL.o  ED_AUX_FUNX.o ED_IO.o ED_SETUP.o ED_EIGENSPACE.o ED_BATH.o ED_BATH_FUNCTIONS.o ED_MATVEC.o ED_HAMILTONIAN.o ED_DIAG.o ED_OBSERVABLES.o ED_GREENS_FUNCTIONS.o  ED_CHI2FIT.o ED_MPI2B.o ED_GLOC.o ED_WEISS.o ED_ENERGY.o ED_MAIN.o DMFT_ED.o
+
+
+#TRY TO USE THE DMFT_TOOLS ONES
+#
 
 all: all version compile completion
 mpi: mpi version compile completion

--- a/drivers/ed_bhz_2d.f90
+++ b/drivers/ed_bhz_2d.f90
@@ -15,9 +15,10 @@ program ed_bhz
   USE DMFT_ED
   USE SCIFOR
   USE DMFT_TOOLS
-#ifdef _MPI
+  ! #ifdef _MPI
   USE MPI
-#endif
+  USE SF_MPI
+  ! #endif
   implicit none
   integer                :: iloop,Lk,Nso
   logical                :: converged
@@ -42,14 +43,18 @@ program ed_bhz
   type(finter_type)      :: finter_func
   !
   real(8),dimension(2)   :: Eout
-  real(8),allocatable :: dens(:)
-#ifdef _MPI
-  call MPI_INIT(ED_MPI_ERR)
-  call MPI_COMM_RANK(MPI_COMM_WORLD,ED_MPI_ID,ED_MPI_ERR)
-  call MPI_COMM_SIZE(MPI_COMM_WORLD,ED_MPI_SIZE,ED_MPI_ERR)
-  write(*,"(A,I4,A,I4,A)")'Processor ',ED_MPI_ID,' of ',ED_MPI_SIZE,' is alive'
-  call MPI_BARRIER(MPI_COMM_WORLD,ED_MPI_ERR)
-#endif
+  real(8),allocatable    :: dens(:)
+  !MPI Vars:
+  integer :: mpiRANK, mpiSIZE, mpiERR
+
+  ! #ifdef _MPI
+  call MPI_INIT(mpiERR)
+  ! call MPI_COMM_RANK(MPI_COMM_WORLD,mpiRANK,mpiERR)
+  ! call MPI_COMM_SIZE(MPI_COMM_WORLD,mpiSIZE,mpiERR)
+  ! write(*,"(A,I4,A,I4,A)")'Processor ',mpiRANK,' of ',mpiSIZE,' is alive'
+  ! call MPI_BARRIER(MPI_COMM_WORLD,mpiERR)
+  call StartMsg_MPI(MPI_COMM_WORLD)
+  ! #endif
 
   !Parse additional variables && read Input && read H(k)^4x4
   call parse_cmd_variable(finput,"FINPUT",default='inputED_BHZ.in')
@@ -67,6 +72,7 @@ program ed_bhz
   call parse_input_variable(lambda,"LAMBDA",finput,default=0.d0)
   !
   call ed_read_input(trim(finput))
+
 
   if(Nspin/=2.OR.Norb/=2)stop "Wrong setup from input file: Nspin=Norb=2 -> 4Spin-Orbitals"
   Nso=Nspin*Norb
@@ -104,17 +110,17 @@ program ed_bhz
   Nb=get_bath_dimension()
   allocate(Bath(Nb))
   allocate(Bath_(Nb))
-  call ed_init_solver(bath)
+  call ed_init_solver(MPI_COMM_WORLD,bath)
   call set_hloc(j2so(bhzHloc))
 
   !DMFT loop
   iloop=0;converged=.false.
   do while(.not.converged.AND.iloop<nloop)
      iloop=iloop+1
-     if(ED_MPI_ID==0)call start_loop(iloop,nloop,"DMFT-loop")
+     if(mpiRANK==0)call start_loop(iloop,nloop,"DMFT-loop")
 
      !Solve the EFFECTIVE IMPURITY PROBLEM (first w/ a guess for the bath)
-     call ed_solve(bath)
+     call ed_solve(MPI_COMM_WORLD,bath)
      call ed_get_sigma_matsubara(Smats)
      call ed_get_sigma_real(Sreal)
      dens= ed_get_dens()
@@ -125,33 +131,51 @@ program ed_bhz
      ! call get_delta
 
      !Fit the new bath, starting from the old bath + the supplied delta
-     call ed_chi2_fitgf(delta(1,1,:,:,:),bath,ispin=1)
+     call ed_chi2_fitgf(MPI_COMM_WORLD,delta(1,1,:,:,:),bath,ispin=1)
      if(.not.spinsym)then
         call ed_chi2_fitgf(delta(2,2,:,:,:),bath,ispin=2)
      else
         call spin_symmetrize_bath(bath,save=.true.)
      endif
+     call Bcast_MPI(MPI_COMM_WORLD,bath)
 
      !MIXING:
      if(iloop>1)Bath = wmixing*Bath + (1.d0-wmixing)*Bath_
      Bath_=Bath
 
-     if(ED_MPI_ID==0)then
+     if(mpiRANK==0)then
         converged = check_convergence(delta(1,1,1,1,:),dmft_error,nsuccess,nloop)
         if(nread/=0.d0)call search_chemical_potential(xmu,sum(dens),converged)
      endif
-#ifdef _MPI
-     call MPI_BCAST(converged,1,MPI_LOGICAL,0,MPI_COMM_WORLD,ED_MPI_ERR)
-     call MPI_BCAST(xmu,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ED_MPI_ERR)
-#endif
-     if(ED_MPI_ID==0)call end_loop
+
+     ! #ifdef _MPI
+     call Bcast_MPI(MPI_COMM_WORLD,converged)
+     call Bcast_MPI(MPI_COMM_WORLD,xmu)
+     ! #endif
+
+     if(mpiRANK==0)call end_loop
   enddo
 
-  Eout = ed_kinetic_energy(Hk,Wtk,Smats)
 
-#ifdef _MPI
-  call MPI_FINALIZE(ED_MPI_ERR)
-#endif
+  if(mpiRANK==0)then
+     Eout = ed_kinetic_energy(Hk,Wtk,Smats)
+     print*,Eout
+  endif
+
+
+  call add_ctrl_var(Norb,"Norb")
+  call add_ctrl_var(Nspin,"Nspin")
+  call add_ctrl_var(beta,"beta")
+  call add_ctrl_var(xmu,"xmu")
+  call add_ctrl_var(wini,"wini")
+  call add_ctrl_var(wfin,"wfin")
+  Eout = dmft_kinetic_energy(MPI_COMM_WORLD,Hk,Wtk,Smats)
+  print*,Eout
+
+  ! #ifdef _MPI
+  call MPI_FINALIZE(mpiERR)
+  ! #endif
+
 contains
 
 
@@ -174,10 +198,10 @@ contains
     real(8)                             :: wm(Lmats),wr(Lreal),dw
     call build_hk_GXMG()
 
-    if(ED_MPI_ID==0)write(LOGfile,*)"Build H(k) for BHZ:"
+    if(mpiRANK==0)write(LOGfile,*)"Build H(k) for BHZ:"
     Lk=Nk**2
-    if(ED_MPI_ID==0)write(*,*)"# of k-points     :",Lk
-    if(ED_MPI_ID==0)write(*,*)"# of SO-bands     :",Nso
+    if(mpiRANK==0)write(*,*)"# of k-points     :",Lk
+    if(mpiRANK==0)write(*,*)"# of SO-bands     :",Nso
     if(allocated(Hk))deallocate(Hk)
     if(allocated(wtk))deallocate(wtk)
     allocate(Hk(Nso,Nso,Lk))
@@ -187,7 +211,7 @@ contains
     kygrid = kgrid(Nk)
     Hk     = build_hk_model(hk_bhz,Nso,kxgrid,kygrid,[0d0])
     wtk = 1d0/Lk
-    if(ED_MPI_ID==0.AND.present(file))then
+    if(mpiRANK==0.AND.present(file))then
        call write_hk_w90(file,Nso,&
             Nd=Norb,&
             Np=1,   &
@@ -200,7 +224,7 @@ contains
     allocate(bhzHloc(Nso,Nso))
     bhzHloc = sum(Hk(:,:,:),dim=3)/Lk
     where(abs(dreal(bhzHloc))<1.d-9)bhzHloc=0d0
-    if(ED_MPI_ID==0)call write_Hloc(bhzHloc)
+    if(mpiRANK==0)call write_Hloc(bhzHloc)
     !Build the local GF:
     wm = pi/beta*real(2*arange(1,Lmats)-1,8)
     wr = linspace(wini,wfin,Lreal,mesh=dw)
@@ -235,14 +259,14 @@ contains
     !This routine build the H(k) along the GXMG path in BZ,
     !Hk(k) is constructed along this path.
     if(present(kpath_))then
-       if(ED_MPI_ID==0)write(LOGfile,*)"Build H(k) BHZ along a given path:"
+       if(mpiRANK==0)write(LOGfile,*)"Build H(k) BHZ along a given path:"
        Npts = size(kpath_,1)
        Lk=(Npts-1)*Nkpath
        allocate(kpath(Npts,size(kpath_,2)))
        kpath=kpath_
        file="Eig_path.nint"
     else
-       if(ED_MPI_ID==0)write(LOGfile,*)"Build H(k) BHZ along the path GXMG:"
+       if(mpiRANK==0)write(LOGfile,*)"Build H(k) BHZ along the path GXMG:"
        Npts = 4
        Lk=(Npts-1)*Nkpath
        allocate(kpath(Npts,3))
@@ -258,7 +282,7 @@ contains
     allocate(wtk(Lk))
     Hk     = build_hk_model(hk_bhz,Nso,kpath,Nkpath)
     wtk = 1d0/Lk
-    if(ED_MPI_ID==0)  call solve_Hk_along_BZpath(hk_bhz,Nso,kpath,Lk,&
+    if(mpiRANK==0)  call solve_Hk_along_BZpath(hk_bhz,Nso,kpath,Lk,&
          colors_name=[red1,blue1,red1,blue1],&
          points_name=[character(len=20) :: 'G', 'M', 'X', 'G'],&
          file=reg(file))
@@ -270,106 +294,106 @@ contains
 
 
 
-  !---------------------------------------------------------------------
-  !PURPOSE: GET DELTA FUNCTION
-  !---------------------------------------------------------------------
-  subroutine get_delta
-    integer                                     :: i,j,ik,iorb,jorb,ispin,jspin,iso,unit
-    complex(8),dimension(Nso,Nso)               :: zeta,fg,gdelta
-    complex(8),dimension(:,:,:),allocatable     :: Smats
-    complex(8),dimension(:,:,:,:,:),allocatable :: gloc
-    complex(8),dimension(:,:,:,:),allocatable   :: gk
-    complex(8)                                  :: iw
-    real(8)                                     :: wm(Lmats),wr(Lreal)
-    character(len=20)                           :: suffix
-    !
-    !
-    wm = pi/beta*real(2*arange(1,Lmats)-1,8)
-    wr = linspace(wini,wfin,Lreal)
-    delta = zero
-    !
-    !MATSUBARA AXIS
-    if(ED_MPI_ID==0)print*,"Get Gloc_iw:"
-    allocate(gloc(Nspin,Nspin,Norb,Norb,Lmats))
-    do i=1,Lmats
-       iw = xi*wm(i)
-       forall(iorb=1:Nso)zeta(iorb,iorb)=iw+xmu
-       zeta(:,:) = zeta(:,:) - so2j(impSmats(:,:,:,:,i),Nso)
-       fg=zero
-       if(lambda==0.d0)then
-          do ik=1,Lk
-             forall(iorb=1:Nso)&
-                  fg(iorb,iorb) = fg(iorb,iorb) + Wtk(ik)/(zeta(iorb,iorb)-Hk(iorb,iorb,ik))
-          enddo
-          gloc(:,:,:,:,i) = j2so(fg)
-          !Get Delta=\Delta or G_0
-          gdelta=zero
-          forall(iorb=1:Nso)fg(iorb,iorb)=one/fg(iorb,iorb)
-          if(cg_scheme=='weiss')then
-             gdelta = fg + so2j(impSmats(:,:,:,:,i),Nso)
-             forall(iorb=1:Nso)gdelta(iorb,iorb)=one/gdelta(iorb,iorb)
-          else
-             forall(iorb=1:Nso)gdelta(iorb,iorb) = zeta(iorb,iorb) - bhzHloc(iorb,iorb) - fg(iorb,iorb)
-          endif
-       else
-          do ik=1,Lk
-             fg = fg + inverse_gk(zeta,Hk(:,:,ik))*Wtk(ik)
-          enddo
-          gloc(:,:,:,:,i) = j2so(fg)
-          !Get Delta=\Delta or G_0
-          call matrix_inverse(fg)
-          if(cg_scheme=='weiss')then
-             gdelta = fg + so2j(impSmats(:,:,:,:,i),Nso)
-             call matrix_inverse(gdelta)
-          else
-             gdelta = zeta(:,:) - bhzHloc - fg(:,:)
-          endif
-       endif
-       !
-       delta(:,:,:,:,i) = j2so(gdelta(:,:))
-       !
-    enddo
-    if(ED_MPI_ID==0)then
-       do ispin=1,Nspin
-          do iorb=1,Norb
-             suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
-             call splot("Delta"//reg(suffix),wm,delta(ispin,ispin,iorb,iorb,:))
-             call splot("Gloc"//reg(suffix),wm,gloc(ispin,ispin,iorb,iorb,:))
-          enddo
-       enddo
-    endif
-    deallocate(gloc)
-    !
-    !REAL AXIS
-    allocate(gloc(Nspin,Nspin,Norb,Norb,Lreal))
-    if(ED_MPI_ID==0)print*,"Get Gloc_realw:"
-    do i=1,Lreal
-       iw=dcmplx(wr(i),eps)
-       forall(iorb=1:Nso)zeta(iorb,iorb)=iw+xmu
-       zeta(:,:) = zeta(:,:) - so2j(impSreal(:,:,:,:,i),Nso)
-       fg=zero
-       do ik=1,Lk         
-          fg = fg + inverse_gk(zeta,Hk(:,:,ik))*wtk(ik)
-       enddo
-       gloc(:,:,:,:,i) = j2so(fg)
-    enddo
-    if(ED_MPI_ID==0)then
-       do ispin=1,Nspin
-          do iorb=1,Norb
-             suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
-             call splot("Gloc"//reg(suffix),wr,-dimag(gloc(ispin,ispin,iorb,iorb,:))/pi,dreal(gloc(ispin,ispin,iorb,iorb,:)))
-          enddo
-       enddo
-    endif
-    deallocate(gloc)
-    ! !Get Kinetic Energy too
-    ! allocate(Smats(Nso,Nso,Lmats))
-    ! do i=1,Lmats
-    !    Smats(:,:,i)=so2j(impSmats(:,:,:,:,i),Nso)
-    ! enddo
-    ! call ed_kinetic_energy(Hk,wtk,Smats)
-    ! deallocate(Smats)
-  end subroutine get_delta
+  ! !---------------------------------------------------------------------
+  ! !PURPOSE: GET DELTA FUNCTION
+  ! !---------------------------------------------------------------------
+  ! subroutine get_delta
+  !   integer                                     :: i,j,ik,iorb,jorb,ispin,jspin,iso,unit
+  !   complex(8),dimension(Nso,Nso)               :: zeta,fg,gdelta
+  !   complex(8),dimension(:,:,:),allocatable     :: Smats
+  !   complex(8),dimension(:,:,:,:,:),allocatable :: gloc
+  !   complex(8),dimension(:,:,:,:),allocatable   :: gk
+  !   complex(8)                                  :: iw
+  !   real(8)                                     :: wm(Lmats),wr(Lreal)
+  !   character(len=20)                           :: suffix
+  !   !
+  !   !
+  !   wm = pi/beta*real(2*arange(1,Lmats)-1,8)
+  !   wr = linspace(wini,wfin,Lreal)
+  !   delta = zero
+  !   !
+  !   !MATSUBARA AXIS
+  !   if(mpiRANK==0)print*,"Get Gloc_iw:"
+  !   allocate(gloc(Nspin,Nspin,Norb,Norb,Lmats))
+  !   do i=1,Lmats
+  !      iw = xi*wm(i)
+  !      forall(iorb=1:Nso)zeta(iorb,iorb)=iw+xmu
+  !      zeta(:,:) = zeta(:,:) - so2j(impSmats(:,:,:,:,i),Nso)
+  !      fg=zero
+  !      if(lambda==0.d0)then
+  !         do ik=1,Lk
+  !            forall(iorb=1:Nso)&
+  !                 fg(iorb,iorb) = fg(iorb,iorb) + Wtk(ik)/(zeta(iorb,iorb)-Hk(iorb,iorb,ik))
+  !         enddo
+  !         gloc(:,:,:,:,i) = j2so(fg)
+  !         !Get Delta=\Delta or G_0
+  !         gdelta=zero
+  !         forall(iorb=1:Nso)fg(iorb,iorb)=one/fg(iorb,iorb)
+  !         if(cg_scheme=='weiss')then
+  !            gdelta = fg + so2j(impSmats(:,:,:,:,i),Nso)
+  !            forall(iorb=1:Nso)gdelta(iorb,iorb)=one/gdelta(iorb,iorb)
+  !         else
+  !            forall(iorb=1:Nso)gdelta(iorb,iorb) = zeta(iorb,iorb) - bhzHloc(iorb,iorb) - fg(iorb,iorb)
+  !         endif
+  !      else
+  !         do ik=1,Lk
+  !            fg = fg + inverse_gk(zeta,Hk(:,:,ik))*Wtk(ik)
+  !         enddo
+  !         gloc(:,:,:,:,i) = j2so(fg)
+  !         !Get Delta=\Delta or G_0
+  !         call matrix_inverse(fg)
+  !         if(cg_scheme=='weiss')then
+  !            gdelta = fg + so2j(impSmats(:,:,:,:,i),Nso)
+  !            call matrix_inverse(gdelta)
+  !         else
+  !            gdelta = zeta(:,:) - bhzHloc - fg(:,:)
+  !         endif
+  !      endif
+  !      !
+  !      delta(:,:,:,:,i) = j2so(gdelta(:,:))
+  !      !
+  !   enddo
+  !   if(mpiRANK==0)then
+  !      do ispin=1,Nspin
+  !         do iorb=1,Norb
+  !            suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_iw.ed"
+  !            call splot("Delta"//reg(suffix),wm,delta(ispin,ispin,iorb,iorb,:))
+  !            call splot("Gloc"//reg(suffix),wm,gloc(ispin,ispin,iorb,iorb,:))
+  !         enddo
+  !      enddo
+  !   endif
+  !   deallocate(gloc)
+  !   !
+  !   !REAL AXIS
+  !   allocate(gloc(Nspin,Nspin,Norb,Norb,Lreal))
+  !   if(mpiRANK==0)print*,"Get Gloc_realw:"
+  !   do i=1,Lreal
+  !      iw=dcmplx(wr(i),eps)
+  !      forall(iorb=1:Nso)zeta(iorb,iorb)=iw+xmu
+  !      zeta(:,:) = zeta(:,:) - so2j(impSreal(:,:,:,:,i),Nso)
+  !      fg=zero
+  !      do ik=1,Lk         
+  !         fg = fg + inverse_gk(zeta,Hk(:,:,ik))*wtk(ik)
+  !      enddo
+  !      gloc(:,:,:,:,i) = j2so(fg)
+  !   enddo
+  !   if(mpiRANK==0)then
+  !      do ispin=1,Nspin
+  !         do iorb=1,Norb
+  !            suffix="_l"//reg(txtfy(iorb))//"_s"//reg(txtfy(ispin))//"_realw.ed"
+  !            call splot("Gloc"//reg(suffix),wr,-dimag(gloc(ispin,ispin,iorb,iorb,:))/pi,dreal(gloc(ispin,ispin,iorb,iorb,:)))
+  !         enddo
+  !      enddo
+  !   endif
+  !   deallocate(gloc)
+  !   ! !Get Kinetic Energy too
+  !   ! allocate(Smats(Nso,Nso,Lmats))
+  !   ! do i=1,Lmats
+  !   !    Smats(:,:,i)=so2j(impSmats(:,:,:,:,i),Nso)
+  !   ! enddo
+  !   ! call ed_kinetic_energy(Hk,wtk,Smats)
+  !   ! deallocate(Smats)
+  ! end subroutine get_delta
 
 
 
@@ -396,7 +420,7 @@ contains
     real(8)                                     :: wr_(Lreal),wr(Lw)
     real(8),dimension(:,:),allocatable          :: Kpath
     character(len=20)                           :: suffix
-    if(ED_MPI_ID==0)then
+    if(mpiRANK==0)then
        !
        wr_ = linspace(wini,wfin,Lreal)
        wr  = linspace(-akrange,akrange,Lw)

--- a/drivers/ed_nano.f90
+++ b/drivers/ed_nano.f90
@@ -65,7 +65,7 @@ program ed_nano
   call parse_input_variable(kinetic,"kinetic",finput,default=.false.)
 
   ! read input
-  call ed_read_input(trim(finput))
+  call ed_read_input(trim(finput),MPI_COMM_WORLD)
 
   ! set input structure hamiltonian
   call build_Hij([nfile,hijfile])
@@ -112,8 +112,23 @@ program ed_nano
         Sreal(ilat,:,:,:,:,:) = Sreal_ineq(ineq,:,:,:,:,:)
      enddo
      !
+
+     !THIS SETS THE COMMUNICATOR FOR THE MODULES NOT DIRECTLY INCLUDED IN ED (i.e.KineticEnergy,GetGloc,Weiss,etc)
+     call ed_set_MPI(MPI_COMM_WORLD)
+
      ! computes the kinetic energy
-     Eout = ed_kinetic_energy_lattice(Hij,[1d0],Smats)
+     Eout = ed_kinetic_energy(Hij,[1d0],Smats)
+     print*,Eout
+
+     call add_ctrl_var(Norb,"Norb")
+     call add_ctrl_var(Nspin,"Nspin")
+     call add_ctrl_var(beta,"beta")
+     call add_ctrl_var(xmu,"xmu")
+     call add_ctrl_var(wini,"wini")
+     call add_ctrl_var(wfin,"wfin")
+     Eout = dmft_kinetic_energy(MPI_COMM_WORLD,Hij,[1d0],Smats(:,1,1,1,1,:))
+     print*,Eout
+
      stop
   endif
 
@@ -206,13 +221,15 @@ program ed_nano
   endif
 
 
+  !###################################################################################################
+
 
   ! setup solver
   Nb=get_bath_dimension()
 
   allocate(Bath_ineq(Nineq,Nb))
   allocate(Bath_prev(Nineq,Nb))
-  call ed_init_solver(Bath_ineq)
+  call ed_init_solver(MPI_COMM_WORLD,Bath_ineq)
 
   do ineq=1,Nineq
      ilat = ineq2lat(ineq)
@@ -222,6 +239,9 @@ program ed_nano
   enddo
 
 
+  !THIS SETS THE COMMUNICATOR FOR THE MODULES NOT DIRECTLY INCLUDED IN ED (i.e.KineticEnergy,GetGloc,Weiss,etc)
+  call ed_set_MPI(MPI_COMM_WORLD)
+
   iloop=0 ; converged=.false.
   do while(.not.converged.AND.iloop<nloop) 
      iloop=iloop+1
@@ -229,7 +249,7 @@ program ed_nano
      bath_prev=bath_ineq
 
      ! solve impurities on each inequivalent site:
-     call ed_solve(bath_ineq,Hloc_ineq,iprint=0)
+     call ed_solve(MPI_COMM_WORLD,bath_ineq,Hloc_ineq,iprint=0)
 
      ! retrieve self-energies and occupations(Nineq,Norb=1)
      call ed_get_sigma_matsubara_lattice(Smats_ineq,Nineq)
@@ -259,13 +279,12 @@ program ed_nano
      enddo
 
 
-
      ! compute the Weiss field
      call ed_get_weiss_lattice(Gmats_ineq,Smats_ineq,Weiss_ineq,Hloc_ineq,iprint=0)
 
      ! fit baths and mix result with old baths
      do ispin=1,Nspin
-        call ed_chi2_fitgf_lattice(bath_ineq,Weiss_ineq,Hloc_ineq,ispin)
+        call ed_chi2_fitgf(MPI_COMM_WORLD,bath_ineq,Weiss_ineq,Hloc_ineq,ispin)
      enddo
 
      if(phsym)then
@@ -281,8 +300,8 @@ program ed_nano
         if(NREAD/=0.d0) call search_chemical_potential(xmu,sum(dens)/Nlat,converged)
      endif
 #ifdef _MPI
-     call MPI_BCAST(converged,1,MPI_LOGICAL,0,MPI_COMM_WORLD,ED_MPI_ERR)
-     call MPI_BCAST(xmu,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ED_MPI_ERR)
+     call MPI_BCAST(converged,1,MPI_LOGICAL,0,MPI_COMM_WORLD,mpiERR)
+     call MPI_BCAST(xmu,1,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,mpiERR)
 #endif
      if(mpiID==0) call end_loop()
   end do
@@ -290,7 +309,17 @@ program ed_nano
 
   call save_sigma(Smats_ineq,Sreal_ineq)
 
-  Eout = ed_kinetic_energy_lattice(Hij,[1d0],Smats)
+  Eout = ed_kinetic_energy(Hij,[1d0],Smats)
+  print*,Eout
+
+  call add_ctrl_var(Norb,"Norb")
+  call add_ctrl_var(Nspin,"Nspin")
+  call add_ctrl_var(beta,"beta")
+  call add_ctrl_var(xmu,"xmu")
+  call add_ctrl_var(wini,"wini")
+  call add_ctrl_var(wfin,"wfin")
+  Eout = dmft_kinetic_energy(MPI_COMM_WORLD,Hij,[1d0],Smats(:,1,1,1,1,:))
+  print*,Eout
 
 
 #ifdef _MPI
@@ -931,8 +960,8 @@ contains
     endif
     deallocate(lead_real,lead_mats,wr,wm)
     !
-    call MPI_Bcast(hyb_real,size(hyb_real),MPI_DOUBLE_COMPLEX,0,MPI_COMM_WORLD,ED_MPI_ERR)
-    call MPI_Bcast(hyb_mats,size(hyb_mats),MPI_DOUBLE_COMPLEX,0,MPI_COMM_WORLD,ED_MPI_ERR)
+    call MPI_Bcast(hyb_real,size(hyb_real),MPI_DOUBLE_COMPLEX,0,MPI_COMM_WORLD,mpiERR)
+    call MPI_Bcast(hyb_mats,size(hyb_mats),MPI_DOUBLE_COMPLEX,0,MPI_COMM_WORLD,mpiERR)
     !
   end subroutine set_hyb
 

--- a/make.inc
+++ b/make.inc
@@ -5,7 +5,7 @@ FC=mpif90
 ##$ PLATFORM: supported platform are intel, gnu
 ##$ if using a parallel compiler (mpif90) check
 ##$ platform first using the cmd: $mpif90 -show
-PLAT=intel
+PLAT=gnu
 
 ##$ LOCATION OF THE scifor and dmft_tools DIRECTORIES
 ##$ is placed in different locations edit INCARGS here below
@@ -68,7 +68,9 @@ ifeq ($(PLAT),gnu)
 INCARGS=-I$(LIBDIR)/scifor/gnu/include -L$(LIBDIR)/scifor/gnu/lib
 INCARGS+=-I$(LIBDIR)/dmft_tools/gnu/include -L$(LIBDIR)/dmft_tools/gnu/lib
 FFLAG = -O2 -funroll-all-loops -ffree-line-length-none $(INCARGS) 
-DFLAG = -O0 -p -g -Wall -fimplicit-none -ffpe-trap=zero,overflow,underflow  -Wall  -Wline-truncation  -Wcharacter-truncation  -Wsurprising  -Waliasing  -Wimplicit-interface  -Wunused-parameter  -fwhole-file  -fcheck=all  -pedantic  -fbacktrace -fcheck=bounds -ffree-line-length-none  $(INCARGS)
+DFLAG = -O0 -p -g -fimplicit-none -Wsurprising  -Waliasing -fwhole-file -fcheck=all -pedantic -fbacktrace -ffree-line-length-none  $(INCARGS)
+
+#DFLAG = -O0 -p -g -Wall -fimplicit-none -ffpe-trap=zero,overflow,underflow  -Wall  -Wline-truncation  -Wcharacter-truncation  -Wsurprising  -Waliasing  -Wimplicit-interface  -Wunused-parameter  -fwhole-file  -fcheck=all  -pedantic  -fbacktrace -fcheck=bounds -ffree-line-length-none  $(INCARGS)
 OFLAG = -O3 -ffast-math -march=native -funroll-all-loops -fno-protect-parens -flto -ffree-line-length-none $(INCARGS)
 FPPFLAG =-cpp
 endif


### PR DESCRIPTION
THE MPI STRUCTUR OF THE CODE HAS BEEN ENTIRELY RE-WRITTEN!

update: fixed a bug in CHI2FIT
update: tested DMFT_EKIN. Works in bhz_2d perfectly. bug in nano. working on it

I rewrote the entire MPI structure of the code. The goal was to
have a single MPI environment (no more _MPI and _MPI_INEQ, inherited
from RDMFT). I also avoided to have a single global MPI communicator
shared among the entire code: this led to malfunctioning in the
case of colored_MPI tests and in any case it is no safe.

In this version I adopted the following strategy:
Modules are divided in two groups:
MPI FREE
NON MPI FREE

The first group contains modules that do not need to know about MPI.
The second group contains modules which rely on MPI for some operations. The
latter contains all the ED modules relevant to ED_MAIN:
ED_SETUP
ED_MATVEC
ED_HAMILTONIAN
ED_DIAG
ED_OBSERVABLES
ED_GREENS_FUNCTIONS

In order to preserve MPI locality each module is endowed with a local communicator
and MPI variables. These are set/deleted only via specific procedures, which in
the case of non  MPI compilation do just nothing.
If MPI is set (MpiStatus=T) then MPI strategy is adopted everywhere, otherwise
**also in presence of _MPI pre-compiltion**, serial strategy is adopted.
IMPORTANT: this allows to run serially even with a MPI compilation!!!
This is Fundamental for at least two reasons:
a) users can compile serial drivers even getting a full MPI ED code;
b) inequivalent sites can be solved serially and the MPI is used to
work out different sites.

So, the communicators set/del are called directly from the top level
interfaces in ED_MAIN. These are doubled (P-ARPACK style):
a) one class of procedures for serial calls
b) one class of procedures for parallel calls

from the user point of view b) differs from the a) only becayse it
REQUIRES the MPI COMMUNICATOR as first input, e.g.

call ed_solve(bath)

vs.

call ed_solve(MPI_COMM_WORLD,bath)

first is serial, the second is parallel.

**
The user is in charge of doing the right thing
**

This modification will requires users to updates their drivers. Sorry!
Also it requires to update SciFortran and DMFT_Tools.

COde has been tested with
ed_bhz_2d
ed_nano

Identical results so far both in serial and parallel mode.